### PR TITLE
Use prison's general_ledger_code for the business unit entry in ADI

### DIFF
--- a/mtp_bank_admin/apps/bank_admin/adi.py
+++ b/mtp_bank_admin/apps/bank_admin/adi.py
@@ -143,7 +143,7 @@ def generate_adi_payment_file(request):
             )
         journal.add_payment_row(
             total_credit, RecordType.credit,
-            prison_id=transaction_list[0]['prison']['nomis_id'],
+            prison_ledger_code=transaction_list[0]['prison']['general_ledger_code'],
             prison_name=transaction_list[0]['prison']['name'],
             date=today
         )

--- a/mtp_bank_admin/apps/bank_admin/adi_config.py
+++ b/mtp_bank_admin/apps/bank_admin/adi_config.py
@@ -55,7 +55,7 @@ ADI_JOURNAL_FIELDS = {
     'business_unit': {
         'column': 'D',
         'value': {
-            'payment': {'debit': '535', 'credit': '{prison_id}'},
+            'payment': {'debit': '535', 'credit': '{prison_ledger_code}'},
             'refund': {'debit': '535', 'credit': '535'},
         },
         'style': _white_style

--- a/mtp_bank_admin/apps/bank_admin/tests/test_adi.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_adi.py
@@ -12,9 +12,9 @@ from ..exceptions import EmptyFileError
 from ..types import PaymentType
 
 TEST_PRISONS = [
-    {'nomis_id': '048', 'name': 'Big Prison'},
-    {'nomis_id': '067', 'name': 'Dark Prison'},
-    {'nomis_id': '054', 'name': 'Scary Prison'}
+    {'nomis_id': 'BPR', 'general_ledger_code': '048', 'name': 'Big Prison'},
+    {'nomis_id': 'DPR', 'general_ledger_code': '067',  'name': 'Dark Prison'},
+    {'nomis_id': 'SPR', 'general_ledger_code': '054',  'name': 'Scary Prison'}
 ]
 
 NO_TRANSACTIONS = {'count': 0, 'results': []}
@@ -133,7 +133,7 @@ class AdiPaymentFileGenerationTestCase(SimpleTestCase):
 
         prison_totals = {}
         for prison in TEST_PRISONS:
-            prison_totals[prison['nomis_id']] = float(sum(
+            prison_totals[prison['general_ledger_code']] = float(sum(
                 [t['amount'] for t in test_data['results']
                     if 'prison' in t and t['prison'] == prison]
             ))


### PR DESCRIPTION
This is a change to correctly use the numeric general_ledger_code
associated with a prison which is used by Phoenix in the ADI
reconciliation files, as opposed to the nomis_id used by NOMIS.