### PR TITLE
Only display refund dowload link if user has perm

### DIFF
--- a/mtp_bank_admin/apps/bank_admin/tests/test_views.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_views.py
@@ -40,6 +40,53 @@ class BankAdminViewTestCase(SimpleTestCase):
         self.assertRedirects(response, redirect_url)
 
 
+class DashboardButtonVisibilityTestCase(BankAdminViewTestCase):
+
+    @mock.patch('moj_auth.backends.api_client')
+    def test_can_see_refund_download_with_perm(self, mock_api_client):
+        mock_api_client.authenticate.return_value = {
+            'pk': 5,
+            'token': generate_tokens(),
+            'user_data': {
+                'first_name': 'Sam',
+                'last_name': 'Hall',
+                'username': 'shall',
+                'permissions': ['transaction.view_bank_details_transaction']
+            }
+        }
+
+        response = self.client.post(
+            reverse('login'),
+            data={'username': 'shall', 'password': 'pass'},
+            follow=True
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, reverse('bank_admin:download_refund_file'))
+
+    @mock.patch('moj_auth.backends.api_client')
+    def test_cannot_see_refund_download_without_perm(self, mock_api_client):
+        mock_api_client.authenticate.return_value = {
+            'pk': 5,
+            'token': generate_tokens(),
+            'user_data': {
+                'first_name': 'Sam',
+                'last_name': 'Hall',
+                'username': 'shall',
+                'permissions': []
+            }
+        }
+
+        response = self.client.post(
+            reverse('login'),
+            data={'username': 'shall', 'password': 'pass'},
+            follow=True
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, reverse('bank_admin:download_refund_file'))
+
+
 class DownloadRefundFileViewTestCase(BankAdminViewTestCase):
 
     def test_dashboard_requires_login(self):

--- a/mtp_bank_admin/apps/bank_admin/urls.py
+++ b/mtp_bank_admin/apps/bank_admin/urls.py
@@ -9,7 +9,7 @@ urlpatterns = [
     url(r'^$', login_required(TemplateView.as_view(
         template_name='bank_admin/dashboard.html')),
         name='dashboard'),
-    url(r'^refund/download/$', views.download_refund_file,
+    url(r'^refund_pending/download/$', views.download_refund_file,
         name='download_refund_file'),
     url(r'^adi/payment/download/$', views.download_adi_payment_file,
         name='download_adi_payment_file'),

--- a/mtp_bank_admin/templates/bank_admin/dashboard.html
+++ b/mtp_bank_admin/templates/bank_admin/dashboard.html
@@ -10,12 +10,16 @@
 </ul>
 <p/>
 {% endif %}
+{% if perms.transaction.view_bank_details_transaction %}
 <a href="{% url "bank_admin:download_refund_file" %}">
 	{% trans "Download Refunds" %}
 </a>
+<br/>
+{% endif %}
 <a href="{% url "bank_admin:download_adi_payment_file" %}">
 	{% trans "Download ADI Payment Reconciliation File" %}
 </a>
+<br/>
 <a href="{% url "bank_admin:download_adi_refund_file" %}">
 	{% trans "Download ADI Refund Reconciliation File" %}
 </a>


### PR DESCRIPTION
The button to download the file containing transactions to be
refunded - and the account details of the refundees - will now
only display if the user is actually able to access those
details on the API.