### PR TITLE
Add shared assets setup

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "mtp_bank_admin/assets-src/bower_components"
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.py]
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ staticfiles/
 media/
 .build
 
+# Sass-cache
+*.sass-cache/
+
 # sublime stuff
 *.sublime-workspace
 *.sublime-project
@@ -17,6 +20,12 @@ venv/
 
 # Ignore settings/local.py
 */settings/local.py
+
+# Node Stuff
+node_modules
+
+mtp_bank_admin/assets-src/bower_components
+mtp_bank_admin/assets/
 
 # Docker make targets
 .dev_django_container

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,24 @@
+{
+  "browser": true,
+  "camelcase": true,
+  "curly": true,
+  "eqeqeq": true,
+  "immed": true,
+  "indent": 2,
+  "latedef": true,
+  "newcap": true,
+  "noarg": true,
+  "quotmark": "single",
+  "regexp": true,
+  "undef": true,
+  "unused": true,
+  "strict": true,
+  "trailing": true,
+  "smarttabs": true,
+  "white": true,
+  "jquery": true,
+  "globals": {
+    "moj": true,
+    "_": true
+  }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
 WORKDIR /app
 
+RUN npm install npm -g
+RUN npm config set python python2.7
 RUN npm install -g bower gulp
 
 ADD ./conf/uwsgi /etc/uwsgi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,23 @@
 FROM ubuntu:trusty
 
+RUN locale-gen "en_US.UTF-8"
+ENV LC_CTYPE=en_US.UTF-8
+
+RUN apt-get update && \
+    apt-get install -y software-properties-common python-software-properties
+
+RUN add-apt-repository -y ppa:chris-lea/node.js
+
 RUN apt-get update && \
     apt-get install -y \
         build-essential git python3-all python3-all-dev python3-setuptools \
-        curl libpq-dev ntp python3-pip python-pip
+        curl libpq-dev ntp python3-pip python-pip nodejs
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
 WORKDIR /app
+
+RUN npm install -g bower gulp
 
 ADD ./conf/uwsgi /etc/uwsgi
 
@@ -16,7 +26,11 @@ ADD ./local_files/* /var/local/
 ADD ./requirements/ /app/requirements/
 RUN pip3 install -r requirements/prod.txt
 
+ADD .bowerrc bower.json package.json README.md /app/
+RUN npm install --unsafe-perm
+
 ADD . /app
+RUN gulp
 RUN ./manage.py collectstatic --noinput
 
 EXPOSE 8080

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,14 @@
+{
+  "name": "money-to-prisoners-bank-admin",
+  "version": "0.1.0",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "**/bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "money-to-prisoners-common": "ministryofjustice/money-to-prisoners-common#0.2.1"
+  }
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,151 @@
+/* jshint node: true */
+
+//
+// Gulp tasks are shared across all 3 applications
+// and are stored in an NPM Package:
+// https://github.com/ministryofjustice/money-to-prisoners-gulp-tasks
+//
+
+'use strict';
+
+var browserSync = require('browser-sync');
+var gulp = require('gulp');
+var path = require('path');
+var nconf = require('nconf');
+var argv = require('yargs').argv;
+var mainBowerFiles = require('main-bower-files');
+var getTask = require('money-to-prisoners-gulp-tasks');
+
+// paths
+var vendorFiles = mainBowerFiles();
+var appBase = 'mtp_bank_admin/';
+var src = appBase + 'assets-src/';
+var dest = appBase + 'assets/';
+
+
+function getBowerDir () {
+  nconf
+    .file({ file: './.bowerrc' })
+    .load();
+
+  return path.join(process.cwd(), nconf.get('directory'));
+}
+
+function getModulePaths (module) {
+  var modulePath = path.join(getBowerDir(), module, 'paths.json');
+  var obj = require(modulePath);
+
+  /* jshint camelcase: false */
+  return obj.import_paths;
+}
+
+function getLoadPaths () {
+  var bowerDir = getBowerDir();
+  var govukImportPaths = getModulePaths('govuk-template');
+  var mojularImportPaths = getModulePaths('mojular');
+  var mtpImportPaths = getModulePaths('money-to-prisoners-common');
+  var joined = govukImportPaths.concat(mojularImportPaths).concat(mtpImportPaths);
+
+  joined = joined.map(function(originalPath) {
+    return path.join(bowerDir, originalPath);
+  });
+
+  return joined.concat(bowerDir);
+}
+
+
+gulp.task('clean:css', getTask('clean', {
+  src: dest + 'stylesheets'
+}));
+
+gulp.task('clean:images', getTask('clean', {
+  src: dest + 'images'
+}));
+
+gulp.task('clean:js', getTask('clean', {
+  src: dest + 'javascripts'
+}));
+
+gulp.task('clean', [
+  'clean:css',
+  'clean:images',
+  'clean:js'
+]);
+
+
+gulp.task('sass', ['clean:css'], getTask('scss', {
+  src: src + 'stylesheets/**/*.scss',
+  dest: dest + 'stylesheets/',
+  includePaths: getLoadPaths(),
+  browserSync: browserSync
+}));
+
+gulp.task('minify-css', ['sass'], getTask('minify-css', {
+  src: dest + 'stylesheets/**/*.css',
+  dest: dest + 'stylesheets'
+}));
+
+
+gulp.task('scripts', ['clean:js'], getTask('concat-scripts', {
+  src: vendorFiles.concat([
+    src + 'bower_components/checked-polyfill/checked-polyfill.js',
+    src + 'javascripts/**/*.js',
+  ]),
+  dest: dest + 'javascripts'
+}));
+
+gulp.task('lint', getTask('lint', {
+  src: [
+    src + 'javascripts/**/*.js',
+    'gulpfile.js'
+  ]
+}));
+
+gulp.task('minify-scripts', ['lint', 'scripts'], getTask('minify-scripts', {
+  src: dest + 'javascripts/*.js',
+  dest: dest + 'javascripts'
+}));
+
+
+gulp.task('images', ['clean:images'], getTask('images', {
+  src: [
+    src + 'images/**/*',
+    src + 'bower_components/hopscotch-highlight/src/images/**/*'
+  ],
+  dest: dest + 'images'
+}));
+
+
+gulp.task('build', [
+  'minify-css',
+  'minify-scripts',
+  'images'
+]);
+
+
+gulp.task('serve', ['build'], function () {
+  var host = argv.host || 'localhost';
+  var port = argv.port || 8001;
+  var browsersyncPort = argv.browsersyncport || 3000;
+  var browsersyncUIPort = argv.browsersyncuiport || 3001;
+
+  browserSync.init({
+    proxy: host + ':' + port,
+    open: false,
+    port: browsersyncPort,
+    ui: {
+      port: browsersyncUIPort
+    }
+  });
+
+  gulp.watch('**/templates/**/*').on('change', browserSync.reload);
+  gulp.watch(src + 'stylesheets/**/*', ['sass']);
+  gulp.watch(src + 'images/**', ['img-watch']);
+  gulp.watch(src + 'javascripts/**/*.js', ['js-watch']);
+});
+
+gulp.task('img-watch', ['images'], browserSync.reload);
+gulp.task('js-watch', ['scripts'], browserSync.reload);
+
+
+gulp.task('default', ['build']);

--- a/mtp_bank_admin/assets-src/stylesheets/app-print.scss
+++ b/mtp_bank_admin/assets-src/stylesheets/app-print.scss
@@ -1,0 +1,6 @@
+@charset 'UTF-8';
+
+$is-print: true;
+
+@import 'print-basic';
+@import 'app';

--- a/mtp_bank_admin/assets-src/stylesheets/app.scss
+++ b/mtp_bank_admin/assets-src/stylesheets/app.scss
@@ -1,0 +1,5 @@
+@charset 'UTF-8';
+
+$images-dir: '/static/images/';
+
+@import 'mtp';

--- a/mtp_bank_admin/settings/base.py
+++ b/mtp_bank_admin/settings/base.py
@@ -13,6 +13,14 @@ https://docs.djangoproject.com/en/1.8/ref/settings/
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 import sys
+import json
+
+from os.path import abspath, join, dirname
+
+here = lambda *x: join(abspath(dirname(__file__)), *x)
+PROJECT_ROOT = here("..")
+root = lambda *x: join(abspath(PROJECT_ROOT), *x)
+bower_dir = lambda *x: join(json.load(open(root('..', '.bowerrc')))['directory'], *x)
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 sys.path.insert(0, os.path.join(BASE_DIR, 'apps'))
@@ -22,6 +30,8 @@ sys.path.insert(0, os.path.join(BASE_DIR, 'apps'))
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
+
+TEMPLATE_DEBUG = True
 
 ALLOWED_HOSTS = []
 
@@ -33,8 +43,15 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'bank_admin',
 )
+
+PROJECT_APPS = (
+    'moj_utils',
+    'widget_tweaks',
+    'bank_admin'
+)
+
+INSTALLED_APPS += PROJECT_APPS
 
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -51,7 +68,11 @@ ROOT_URLCONF = 'mtp_bank_admin.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': ['mtp_bank_admin/templates'],
+        'DIRS': [
+            root('templates'),
+            bower_dir('mojular', 'templates'),
+            bower_dir('money-to-prisoners-common', 'templates')
+        ],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -59,6 +80,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'moj_utils.context_processors.debug',
             ],
         },
     },
@@ -92,6 +114,13 @@ USE_TZ = True
 
 STATIC_ROOT = 'static'
 STATIC_URL = '/static/'
+STATICFILES_DIRS = [
+    root('assets'),
+    bower_dir(),
+    bower_dir('mojular', 'assets'),
+    bower_dir('govuk-template', 'assets'),
+    bower_dir('money-to-prisoners-common', 'assets')
+]
 
 SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'
 MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'

--- a/mtp_bank_admin/templates/base.html
+++ b/mtp_bank_admin/templates/base.html
@@ -1,7 +1,6 @@
-<!DOCTYPE html>
-<html>
-<head></head>
-<body>
-{% block content %}{% endblock %}
-</body>
-</html>
+{% extends 'mtp_base.html' %}
+{% load i18n %}
+
+{% block page_title %}{% trans "Bank Admin" %}{% endblock %}
+
+{% block proposition %}{% trans "Bank Admin" %}{% endblock %}

--- a/mtp_bank_admin/templates/mtp_auth/login.html
+++ b/mtp_bank_admin/templates/mtp_auth/login.html
@@ -1,9 +1,5 @@
-{% extends "base.html" %}
+{% extends 'auth/login.html' %}{% load i18n %}
 
-{% block content %}
-<form action="{% url "login" %}" method="post">
-	{% csrf_token %}
-	{{ form }}
-	<input type="submit" value="Submit" />
-</form>
+{% block auth_title %}
+  {% trans 'Bank Admin' %}
 {% endblock %}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "money-to-prisoners-bank-admin",
+  "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ministryofjustice/money-to-prisoners-bank-admin"
+  },
+  "bugs": {
+    "url": "https://github.com/ministryofjustice/money-to-prisoners-bank-admin/issues"
+  },
+  "engines": {
+    "node": "0.10.x"
+  },
+  "config": {
+    "unsafe-perm": true
+  },
+  "scripts": {
+    "start": "./node_modules/gulp/bin/gulp.js serve",
+    "postinstall": "./node_modules/bower/bin/bower --allow-root install"
+  },
+  "license": "MIT",
+  "dependencies": {},
+  "devDependencies": {
+    "bower": "latest",
+    "browser-sync": "^2.9.3",
+    "gulp": "^3.9.0",
+    "main-bower-files": "^2.9.0",
+    "nconf": "^0.7.2",
+    "yargs": "^3.24.0",
+    "money-to-prisoners-gulp-tasks": "ministryofjustice/money-to-prisoners-gulp-tasks#0.1.0"
+  }
+}

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,5 @@
 Django==1.8.3
 openpyxl==2.2.5
+django-widget-tweaks==1.4.1
 git+git://github.com/ministryofjustice/django-moj-auth.git
+git+git://github.com/ministryofjustice/django-utils.git


### PR DESCRIPTION
Assets are now being shared across all 3 frontend app and
are coming from money-to-prisoners-common. This adds the setup needed
to import assets/templates from that package.

This change is part of the following story:

#### User Story [#103077962](https://www.pivotaltracker.com/story/show/103077962)
As a frontend developer,
I want assets/templates used across all frontend apps to be consistent and shared,
So that I don't have to make changes in multiple locations