### PR TITLE
Change file generation to expect amounts in pence from the API

### DIFF
--- a/mtp_bank_admin/apps/bank_admin/adi.py
+++ b/mtp_bank_admin/apps/bank_admin/adi.py
@@ -134,15 +134,16 @@ def generate_adi_payment_file(request):
 
     # do payments
     for _, transaction_list in prison_payments.items():
-        total_credit = sum([Decimal(t['amount']) for t in transaction_list
-                            if t['credited']])
+        credit_total = 0
         for transaction in transaction_list:
+            credit_amount = Decimal(transaction['amount'])/100
+            credit_total += credit_amount
             journal.add_payment_row(
-                transaction['amount'], RecordType.debit,
+                credit_amount, RecordType.debit,
                 unique_id=settings.TRANSACTION_ID_BASE+int(transaction['id'])
             )
         journal.add_payment_row(
-            total_credit, RecordType.credit,
+            credit_total, RecordType.credit,
             prison_ledger_code=transaction_list[0]['prison']['general_ledger_code'],
             prison_name=transaction_list[0]['prison']['name'],
             date=today
@@ -162,10 +163,12 @@ def generate_adi_refund_file(request):
     today = datetime.now().strftime('%d/%m/%Y')
 
     # do refunds
-    refund_total = sum([Decimal(t['amount']) for t in refunds])
+    refund_total = 0
     for refund in refunds:
+        refund_amount = Decimal(refund['amount'])/100
+        refund_total += refund_amount
         journal.add_payment_row(
-            refund['amount'], RecordType.debit,
+            refund_amount, RecordType.debit,
             unique_id=settings.TRANSACTION_ID_BASE+int(refund['id'])
         )
     journal.add_payment_row(refund_total, RecordType.credit, date=today)

--- a/mtp_bank_admin/apps/bank_admin/refund.py
+++ b/mtp_bank_admin/apps/bank_admin/refund.py
@@ -1,6 +1,7 @@
 import csv
 import io
 from datetime import datetime
+from decimal import Decimal
 
 from django.conf import settings
 from moj_auth.backends import api_client
@@ -21,7 +22,7 @@ def generate_refund_file(request):
                 transaction['sender_sort_code'],
                 transaction['sender_account_number'],
                 transaction['sender_name'],
-                transaction['amount'],
+                '%.2f' % (Decimal(transaction['amount'])/100),
                 settings.REFUND_REFERENCE
             ])
             refunded_transactions.append({'id': transaction['id'], 'refunded': True})

--- a/mtp_bank_admin/apps/bank_admin/tests/test_adi.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_adi.py
@@ -1,6 +1,5 @@
 import os
 import random
-from decimal import Decimal
 from contextlib import contextmanager
 
 from openpyxl import load_workbook
@@ -44,7 +43,7 @@ def get_adi_transactions(type, count=20):
             else:
                 transaction['prison'] = TEST_PRISONS[2]
 
-        transaction['amount'] = Decimal(random.randint(500, 5000))/100
+        transaction['amount'] = random.randint(500, 5000)
         transactions.append(transaction)
     return {'count': count, 'results': transactions}
 
@@ -136,7 +135,7 @@ class AdiPaymentFileGenerationTestCase(SimpleTestCase):
             prison_totals[prison['general_ledger_code']] = float(sum(
                 [t['amount'] for t in test_data['results']
                     if 'prison' in t and t['prison'] == prison]
-            ))
+            ))/100
         credits_checked = 0
 
         with temp_file(filename, exceldata) as f:
@@ -229,7 +228,7 @@ class AdiRefundFileGenerationTestCase(SimpleTestCase):
 
         filename, exceldata = adi.generate_adi_refund_file(None)
 
-        refund_total = float(sum([t['amount'] for t in test_data['results']]))
+        refund_total = float(sum([t['amount'] for t in test_data['results']]))/100
         credit_checked = False
 
         with temp_file(filename, exceldata) as f:

--- a/mtp_bank_admin/apps/bank_admin/tests/test_refund.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_refund.py
@@ -11,7 +11,7 @@ REFUND_TRANSACTIONS = [
         'count': 2,
         'results': [{
             'id': '3',
-            'amount': 25.68,
+            'amount': 2568,
             'sender_account_number': '22222222',
             'sender_sort_code': '111111',
             'sender_name': 'John Doe',
@@ -24,7 +24,7 @@ REFUND_TRANSACTIONS = [
         'count': 2,
         'results': [{
             'id': '4',
-            'amount': 18.72,
+            'amount': 1872,
             'sender_account_number': '33333333',
             'sender_sort_code': '999999',
             'sender_name': 'Joe Bloggs',


### PR DESCRIPTION
As the API stores and returns amounts in pence, the file generation
code needs to convert these amounts to pounds and pence for writing
to the ADI journals and AccessPay file.