### PR TITLE
Handle reconciliation state of transactions

### DIFF
--- a/mtp_bank_admin/apps/bank_admin/utils.py
+++ b/mtp_bank_admin/apps/bank_admin/utils.py
@@ -3,10 +3,11 @@ from django.conf import settings
 from moj_auth import api_client
 
 
-def retrieve_all_transactions(request, status):
+def retrieve_all_transactions(request, status, reconciled=False):
     client = api_client.get_connection(request)
     response = client.bank_admin.transactions.get(
         status=status,
+        reconciled=reconciled,
         limit=settings.REQUEST_PAGE_SIZE
     )
     transactions = response.get('results', [])
@@ -16,6 +17,7 @@ def retrieve_all_transactions(request, status):
     while len(transactions) < total_count:
         response = client.bank_admin.transactions.get(
             status=status,
+            reconciled=reconciled,
             limit=settings.REQUEST_PAGE_SIZE,
             offset=settings.REQUEST_PAGE_SIZE*num_reqs
         )


### PR DESCRIPTION
The bank admin front end now queries for unreconciled transactions when generating the ADI journals, and will update transactions included in any generated files as being reconciled.