### PR TITLE
Include debits from bca

### DIFF
--- a/mtp_bank_admin/apps/bank_admin/adi.py
+++ b/mtp_bank_admin/apps/bank_admin/adi.py
@@ -11,7 +11,7 @@ from . import adi_config as config
 from .types import PaymentType, RecordType
 from .exceptions import EmptyFileError
 from .utils import retrieve_all_transactions, create_batch_record,\
-    get_transaction_uid, reconcile_for_date
+    reconcile_for_date
 
 
 class AdiJournal(object):
@@ -136,7 +136,7 @@ def generate_adi_payment_file(request, receipt_date):
             credit_total += credit_amount
             journal.add_payment_row(
                 credit_amount, RecordType.debit,
-                unique_id=get_transaction_uid(transaction)
+                unique_id=str(transaction['ref_code'])
             )
             reconciled_transactions.append(transaction['id'])
         journal.add_payment_row(
@@ -175,7 +175,7 @@ def generate_adi_refund_file(request, receipt_date):
         refund_total += refund_amount
         journal.add_payment_row(
             refund_amount, RecordType.debit,
-            unique_id=get_transaction_uid(refund)
+            unique_id=str(refund['ref_code'])
         )
         reconciled_transactions.append(refund['id'])
     journal.add_payment_row(refund_total, RecordType.credit, date=journal_date)

--- a/mtp_bank_admin/apps/bank_admin/statement.py
+++ b/mtp_bank_admin/apps/bank_admin/statement.py
@@ -5,7 +5,7 @@ from bai2 import bai2, models, constants
 
 from . import BAI2_STMT_LABEL
 from .exceptions import EmptyFileError
-from .utils import retrieve_all_transactions, get_transaction_uid,\
+from .utils import retrieve_all_transactions,\
     create_batch_record, get_daily_file_uid, reconcile_for_date
 
 
@@ -39,19 +39,17 @@ def generate_bank_statement(request, receipt_date):
     debit_total = 0
     for transaction in transactions:
         transaction_record = models.TransactionDetail([])
-        # if no prison found, this is a refund
-        if transaction.get('prison') is None:
+        if transaction['category'] == 'debit':
             transaction_record.type_code = constants.TypeCodes[DEBIT_TYPE_CODE]
             debit_num += 1
             debit_total += transaction['amount']
-        # else it is a valid credit
         else:
             transaction_record.type_code = constants.TypeCodes[CREDIT_TYPE_CODE]
+            transaction_record.text = str(transaction['ref_code'])
             credit_num += 1
             credit_total += transaction['amount']
 
         transaction_record.amount = transaction['amount']
-        transaction_record.text = str(get_transaction_uid(transaction))
         transaction_records.append(transaction_record)
 
     bai2_file = models.Bai2File()

--- a/mtp_bank_admin/apps/bank_admin/tests/__init__.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/__init__.py
@@ -14,7 +14,7 @@ NO_TRANSACTIONS = {'count': 0, 'results': []}
 def get_test_transactions(trans_type=None, count=20):
     transactions = []
     for i in range(count):
-        transaction = {'id': i}
+        transaction = {'id': i, 'category': 'credit'}
         if trans_type == PaymentType.refund or trans_type is None and i % 5:
             transaction['refunded'] = True
         else:
@@ -27,6 +27,7 @@ def get_test_transactions(trans_type=None, count=20):
                 transaction['prison'] = TEST_PRISONS[2]
 
         transaction['amount'] = random.randint(500, 5000)
+        transaction['ref_code'] = '9' + str(random.randint(0, 99999)).zfill(5)
         transactions.append(transaction)
     return {'count': count, 'results': transactions}
 

--- a/mtp_bank_admin/apps/bank_admin/tests/test_adi.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_adi.py
@@ -194,7 +194,7 @@ class AdiPaymentFileGenerationTestCase(SimpleTestCase):
                                                             today)
 
         self.assertTrue(batch_conn.post.side_effect.called)
-        conn.reconcile.post.assert_called_with({'date': today.strftime('%Y-%m-%d')})
+        conn.reconcile.post.assert_called_with({'date': today.isoformat()})
 
 
 @mock.patch('mtp_bank_admin.apps.bank_admin.utils.api_client')
@@ -353,4 +353,4 @@ class AdiRefundFileGenerationTestCase(SimpleTestCase):
                                                            today)
 
         self.assertTrue(batch_conn.post.side_effect.called)
-        conn.reconcile.post.assert_called_with({'date': today.strftime('%Y-%m-%d')})
+        conn.reconcile.post.assert_called_with({'date': today.isoformat()})

--- a/mtp_bank_admin/apps/bank_admin/tests/test_statement.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_statement.py
@@ -1,5 +1,6 @@
 import mock
 from datetime import datetime
+import random
 
 from django.test import SimpleTestCase
 from django.test.client import RequestFactory
@@ -11,6 +12,17 @@ from . import get_test_transactions, NO_TRANSACTIONS, AssertCalledWithBatchReque
 from .. import BAI2_STMT_LABEL
 from ..statement import generate_bank_statement
 from ..exceptions import EmptyFileError
+
+
+def get_test_transactions_for_stmt(count=20):
+    transactions = get_test_transactions(count=int(count*0.75))
+    for i in range(int(count*0.75), count):
+        transaction = {'id': i, 'category': 'credit'}
+        transaction['amount'] = random.randint(500, 5000)
+        transaction['ref_code'] = '9' + str(random.randint(0, 99999)).zfill(5)
+        transactions['results'].append(transaction)
+    transactions['count'] = count
+    return transactions
 
 
 @mock.patch('mtp_bank_admin.apps.bank_admin.utils.api_client')
@@ -26,7 +38,7 @@ class BankStatementGenerationTestCase(SimpleTestCase):
         )
 
     def test_number_of_records_correct(self, mock_api_client):
-        test_data = get_test_transactions()
+        test_data = get_test_transactions_for_stmt()
 
         conn = mock_api_client.get_connection().bank_admin.transactions
         conn.get.return_value = test_data
@@ -51,7 +63,7 @@ class BankStatementGenerationTestCase(SimpleTestCase):
         )
 
     def test_control_totals_correct(self, mock_api_client):
-        test_data = get_test_transactions()
+        test_data = get_test_transactions_for_stmt()
 
         conn = mock_api_client.get_connection().bank_admin.transactions
         conn.get.return_value = test_data
@@ -73,7 +85,7 @@ class BankStatementGenerationTestCase(SimpleTestCase):
         debit_num = 0
         debit_total = 0
         for transaction in test_data['results']:
-            if transaction.get('refunded', False):
+            if transaction['category'] == 'debit':
                 debit_num += 1
                 debit_total += transaction['amount']
             else:
@@ -105,7 +117,7 @@ class BankStatementGenerationTestCase(SimpleTestCase):
         )
 
     def test_reconciles_date(self, mock_api_client):
-        test_data = get_test_transactions()
+        test_data = get_test_transactions_for_stmt()
 
         conn = mock_api_client.get_connection().bank_admin.transactions
         conn.get.return_value = test_data

--- a/mtp_bank_admin/apps/bank_admin/tests/test_statement.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_statement.py
@@ -133,7 +133,7 @@ class BankStatementGenerationTestCase(SimpleTestCase):
                                                today)
         self.assertTrue(batch_conn.post.side_effect.called)
 
-        conn.reconcile.post.assert_called_with({'date': today.strftime('%Y-%m-%d')})
+        conn.reconcile.post.assert_called_with({'date': today.isoformat()})
 
 
 @mock.patch('mtp_bank_admin.apps.bank_admin.utils.api_client')

--- a/mtp_bank_admin/apps/bank_admin/utils.py
+++ b/mtp_bank_admin/apps/bank_admin/utils.py
@@ -54,10 +54,6 @@ def reconcile_for_date(request, date):
         })
 
 
-def get_transaction_uid(transaction):
-    return settings.TRANSACTION_ID_BASE+int(transaction['id'])
-
-
 def get_daily_file_uid():
     int(time.time()) % 86400
 

--- a/mtp_bank_admin/apps/bank_admin/utils.py
+++ b/mtp_bank_admin/apps/bank_admin/utils.py
@@ -50,7 +50,7 @@ def reconcile_for_date(request, date):
     if date:
         client = api_client.get_connection(request)
         client.bank_admin.transactions.reconcile.post({
-            'date': date.strftime('%Y-%m-%d'),
+            'date': date.isoformat(),
         })
 
 

--- a/mtp_bank_admin/settings/base.py
+++ b/mtp_bank_admin/settings/base.py
@@ -131,7 +131,6 @@ REFUND_OUTPUT_FILENAME = 'mtp_accesspay_%d%m%y.csv'
 ADI_TEMPLATE_FILEPATH = 'local_files/adi_template.xlsx'
 ADI_PAYMENT_OUTPUT_FILENAME = 'adi_credit_file_%d%m%y.xlsx'
 ADI_REFUND_OUTPUT_FILENAME = 'adi_refund_file_%d%m%y.xlsx'
-TRANSACTION_ID_BASE = os.environ.get('TRANSACTION_ID_BASE', 100000)
 
 BANK_STMT_SENDER_ID = os.environ.get('BANK_STMT_SENDER_ID', 'NWBKGB2L')
 BANK_STMT_RECEIVER_ID = os.environ.get('BANK_STMT_RECEIVER_ID', '391796')


### PR DESCRIPTION
Previously, the bank statement included payments that had been
refunded as debits. Instead, these are now shown as credits when
they enter the account. Debits are only shown when a corresponding
debit has been uploaded from the BCA (data services) file.