### PR TITLE
Remove using the minified stylesheets

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -76,10 +76,6 @@ gulp.task('sass', ['clean:css'], getTask('scss', {
   browserSync: production ? browserSync : false
 }));
 
-gulp.task('minify-css', ['sass'], getTask('minify-css', {
-  src: paths.dest + 'stylesheets/**/*.css',
-  dest: paths.dest + 'stylesheets'
-}));
 
 gulp.task('scripts', ['clean:js'], function(callback) {
   webpack(require('./webpack.config.js')).run(function(err, stats) {
@@ -121,7 +117,7 @@ gulp.task('images', ['clean:images'], getTask('images', {
 
 
 gulp.task('build', [
-  'minify-css',
+  'sass',
   'minify-scripts',
   'images'
 ]);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "money-to-prisoners-common": "ministryofjustice/money-to-prisoners-common#1.0.10"
+    "money-to-prisoners-common": "ministryofjustice/money-to-prisoners-common#1.0.11"
   }
 }


### PR DESCRIPTION
because:
1. The minified stylesheets (generated using clean-css) break the style on IE8
2. They only give a 2% gain in file size
Until we investigate a new minified that works on IE8 or we (wait for a) fix in clean-css,
we choose just to remove it. [Updates: #110145316]