### PR TITLE
Use the latest common assets resulting in no console.log use

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "money-to-prisoners-common": "ministryofjustice/money-to-prisoners-common#1.0.11"
+    "money-to-prisoners-common": "ministryofjustice/money-to-prisoners-common#1.0.12"
   }
 }


### PR DESCRIPTION
By virtue of using the latest common assets, we are now using the latest mojular
where all use of console.log (which is a problem with legacy browsers) is removed.