### PR TITLE
Add a healthcheck.json view for IRaT support which tests MTP API & Zendesk connectivity

### DIFF
--- a/mtp_bank_admin/apps/bank_admin/healthchecks.py
+++ b/mtp_bank_admin/apps/bank_admin/healthchecks.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-from moj_utils.healthchecks import HealthcheckResponse, UrlHealthcheck, registry
+from moj_irat.healthchecks import HealthcheckResponse, UrlHealthcheck, registry
 from zendesk_tickets.client import zendesk_auth
 
 registry.register_healthcheck(UrlHealthcheck(

--- a/mtp_bank_admin/apps/bank_admin/healthchecks.py
+++ b/mtp_bank_admin/apps/bank_admin/healthchecks.py
@@ -1,0 +1,9 @@
+from django.conf import settings
+
+from moj_utils.healthchecks import UrlHealthcheck, registry
+
+registry.register_healthcheck(UrlHealthcheck(
+    name='api',
+    url='%s/healthcheck.json' % settings.API_URL,
+    value_at_json_path=(True, '*.status'),
+))

--- a/mtp_bank_admin/apps/bank_admin/healthchecks.py
+++ b/mtp_bank_admin/apps/bank_admin/healthchecks.py
@@ -1,9 +1,29 @@
 from django.conf import settings
 
-from moj_utils.healthchecks import UrlHealthcheck, registry
+from moj_utils.healthchecks import HealthcheckResponse, UrlHealthcheck, registry
+from zendesk_tickets.client import zendesk_auth
 
 registry.register_healthcheck(UrlHealthcheck(
     name='api',
     url='%s/healthcheck.json' % settings.API_URL,
     value_at_json_path=(True, '*.status'),
 ))
+
+if settings.ZENDESK_API_USERNAME and settings.ZENDESK_API_TOKEN and \
+        settings.ZENDESK_GROUP_ID:
+    registry.register_healthcheck(UrlHealthcheck(
+        name='zendesk',
+        url='%(base_url)s/api/v2/groups/%(group_id)s.json' % {
+            'base_url': settings.ZENDESK_BASE_URL,
+            'group_id': settings.ZENDESK_GROUP_ID,
+        },
+        headers={'Content-Type': 'application/json'},
+        auth=zendesk_auth(),
+        value_at_json_path=(settings.ZENDESK_GROUP_ID, 'group.id')
+    ))
+else:
+    registry.register_healthcheck(lambda: HealthcheckResponse(
+        name='zendesk',
+        status=False,
+        error='Zendesk API settings not specified',
+    ))

--- a/mtp_bank_admin/apps/bank_admin/utils.py
+++ b/mtp_bank_admin/apps/bank_admin/utils.py
@@ -1,9 +1,9 @@
 import time
 
-from slumber.exceptions import HttpClientError
-from moj_utils import rest
 from moj_auth import api_client
+from moj_utils import rest
 import six
+from slumber.exceptions import HttpClientError
 
 
 def retrieve_all_transactions(request, **kwargs):

--- a/mtp_bank_admin/settings/base.py
+++ b/mtp_bank_admin/settings/base.py
@@ -52,6 +52,8 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.security.SecurityMiddleware',
 )
 
+HEALTHCHECKS = []
+AUTODISCOVER_HEALTHCHECKS = True
 
 # security tightening
 # some overridden in prod/docker settings where SSL is ensured

--- a/mtp_bank_admin/urls.py
+++ b/mtp_bank_admin/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import include, url
 from django.core.urlresolvers import reverse_lazy
 
 from moj_auth import views
-from moj_utils.views import HealthcheckView, PingJsonView
+from moj_irat.views import HealthcheckView, PingJsonView
 
 urlpatterns = [
     url(r'^login/$', views.login, {

--- a/mtp_bank_admin/urls.py
+++ b/mtp_bank_admin/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import include, url
 from django.core.urlresolvers import reverse_lazy
 
 from moj_auth import views
-from moj_utils.views import PingJsonView
+from moj_utils.views import HealthcheckView, PingJsonView
 
 urlpatterns = [
     url(r'^login/$', views.login, {
@@ -22,4 +22,5 @@ urlpatterns = [
         commit_id_key='APP_GIT_COMMIT',
         version_number_key='APP_BUILD_TAG',
     ), name='ping_json'),
+    url(r'^healthcheck.json$', HealthcheckView.as_view(), name='healthcheck_json'),
 ]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,6 +2,7 @@ Django==1.8.6
 openpyxl==2.2.5
 django-widget-tweaks==1.4.1
 git+git://github.com/ministryofjustice/django-moj-auth.git
+git+git://github.com/ministryofjustice/django-moj-irat.git
 git+git://github.com/ministryofjustice/django-utils.git
 git+git://github.com/ministryofjustice/bai2.git
 git+git://github.com/ministryofjustice/django-zendesk-tickets.git


### PR DESCRIPTION
depends on [django-moj-irat#1](https://github.com/ministryofjustice/django-moj-irat/pull/1)