### PR TITLE
Don't pin the version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "money-to-prisoners-common": "ministryofjustice/money-to-prisoners-common#1.0.13"
+    "money-to-prisoners-common": "ministryofjustice/money-to-prisoners-common"
   }
 }


### PR DESCRIPTION
We can then avoid trickling down dependencies in all 3 applications.
This is considered safe as we control the common module