### PR TITLE
Fix bai dates

### DIFF
--- a/mtp_bank_admin/apps/bank_admin/statement.py
+++ b/mtp_bank_admin/apps/bank_admin/statement.py
@@ -68,8 +68,8 @@ def generate_bank_statement(request, receipt_date):
     group_header.ultimate_receiver_id = settings.BANK_STMT_RECEIVER_ID
     group_header.originator_id = settings.BANK_STMT_SENDER_ID
     group_header.group_status = constants.GroupStatus.update
-    group_header.as_of_date = datetime.date.today()
-    group_header.as_of_time = datetime.datetime.utcnow().time()
+    group_header.as_of_date = receipt_date
+    group_header.as_of_time = datetime.time.max
     group_header.currency = settings.BANK_STMT_CURRENCY
     group_header.as_of_date_modifier = constants.AsOfDateModifier.interim_same_day
     bai2_file.children.append(group)

--- a/mtp_bank_admin/apps/bank_admin/statement.py
+++ b/mtp_bank_admin/apps/bank_admin/statement.py
@@ -46,7 +46,8 @@ def generate_bank_statement(request, receipt_date):
             debit_total += transaction['amount']
         else:
             transaction_record.type_code = constants.TypeCodes[CREDIT_TYPE_CODE]
-            transaction_record.text = str(transaction['ref_code'])
+            if transaction.get('ref_code'):
+                transaction_record.text = str(transaction['ref_code'])
             credit_num += 1
             credit_total += transaction['amount']
 


### PR DESCRIPTION
Show transaction receipt date in Group header of bank statement as this is the expected value, rather than the current date.