### PR TITLE
Feature ref_code in refund reference to aid visual reconciliation

### DIFF
--- a/mtp_bank_admin/apps/bank_admin/refund.py
+++ b/mtp_bank_admin/apps/bank_admin/refund.py
@@ -59,7 +59,7 @@ def generate_refund_file(request, transactions):
                 transaction['sender_account_number'],
                 transaction['sender_name'],
                 '%.2f' % (Decimal(transaction['amount'])/100),
-                settings.REFUND_REFERENCE
+                refund_reference(transaction)
             ])
             writer.writerow(list(cells))
 
@@ -67,3 +67,9 @@ def generate_refund_file(request, transactions):
 
     return (date.today().strftime(settings.REFUND_OUTPUT_FILENAME),
             filedata)
+
+
+def refund_reference(transaction):
+    date_part = date.today().strftime('%d%m')
+    ref_part = transaction['ref_code'][1:]
+    return settings.REFUND_REFERENCE % (date_part, ref_part)

--- a/mtp_bank_admin/apps/bank_admin/statement.py
+++ b/mtp_bank_admin/apps/bank_admin/statement.py
@@ -40,6 +40,8 @@ def generate_bank_statement(request, receipt_date):
     debit_total = 0
     for transaction in transactions:
         transaction_record = models.TransactionDetail([])
+        transaction_record.text = str(transaction.get('reference', ''))
+
         if transaction['category'] == 'debit':
             transaction_record.type_code = constants.TypeCodes[DEBIT_TYPE_CODE]
             debit_num += 1

--- a/mtp_bank_admin/apps/bank_admin/tests/__init__.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/__init__.py
@@ -9,12 +9,13 @@ TEST_PRISONS = [
 ]
 
 NO_TRANSACTIONS = {'count': 0, 'results': []}
+ORIGINAL_REF = 'original reference'
 
 
 def get_test_transactions(trans_type=None, count=20):
     transactions = []
     for i in range(count):
-        transaction = {'id': i, 'category': 'credit'}
+        transaction = {'id': i, 'category': 'credit', 'source': 'bank_transfer'}
         if trans_type == PaymentType.refund or trans_type is None and i % 5:
             transaction['refunded'] = True
         else:
@@ -28,6 +29,7 @@ def get_test_transactions(trans_type=None, count=20):
 
         transaction['amount'] = random.randint(500, 5000)
         transaction['ref_code'] = '9' + str(random.randint(0, 99999)).zfill(5)
+        transaction['reference'] = ORIGINAL_REF
         transactions.append(transaction)
     return {'count': count, 'results': transactions}
 

--- a/mtp_bank_admin/apps/bank_admin/tests/test_statement.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_statement.py
@@ -8,7 +8,10 @@ from django.core.urlresolvers import reverse
 from bai2 import bai2
 from bai2.constants import TypeCodes
 
-from . import get_test_transactions, NO_TRANSACTIONS, AssertCalledWithBatchRequest
+from . import (
+    get_test_transactions, NO_TRANSACTIONS, ORIGINAL_REF,
+    AssertCalledWithBatchRequest
+)
 from .. import BAI2_STMT_LABEL
 from ..statement import generate_bank_statement
 from ..exceptions import EmptyFileError
@@ -17,12 +20,38 @@ from ..exceptions import EmptyFileError
 def get_test_transactions_for_stmt(count=20):
     transactions = get_test_transactions(count=int(count*0.75))
     for i in range(int(count*0.75), count):
-        transaction = {'id': i, 'category': 'credit'}
+        transaction = {'id': i, 'category': 'debit', 'source': 'administrative'}
         transaction['amount'] = random.randint(500, 5000)
-        transaction['ref_code'] = '9' + str(random.randint(0, 99999)).zfill(5)
+        transaction['reference'] = ORIGINAL_REF
         transactions['results'].append(transaction)
     transactions['count'] = count
     return transactions
+
+
+def mock_test_transactions(mock_api_client):
+    test_data = get_test_transactions_for_stmt()
+    conn = mock_api_client.get_connection().bank_admin.transactions
+    conn.get.return_value = test_data
+
+    return conn, test_data
+
+
+def mock_balance(mock_api_client):
+    balance_conn = mock_api_client.get_connection().balances
+    balance_conn.get.return_value = {'count': 1,
+                                     'results': [{'closing_balance': 20000}]}
+
+    return balance_conn
+
+
+def mock_batch(test_case, mock_api_client, test_data):
+    batch_conn = mock_api_client.get_connection().batches
+    batch_conn.post.side_effect = AssertCalledWithBatchRequest(test_case, {
+        'label': BAI2_STMT_LABEL,
+        'transactions': [t['id'] for t in test_data['results']]
+    })
+
+    return batch_conn
 
 
 @mock.patch('mtp_bank_admin.apps.bank_admin.utils.api_client')
@@ -38,20 +67,9 @@ class BankStatementGenerationTestCase(SimpleTestCase):
         )
 
     def test_number_of_records_correct(self, mock_api_client):
-        test_data = get_test_transactions_for_stmt()
-
-        conn = mock_api_client.get_connection().bank_admin.transactions
-        conn.get.return_value = test_data
-
-        balance_conn = mock_api_client.get_connection().balances
-        balance_conn.get.return_value = {'count': 1,
-                                         'results': [{'closing_balance': 20000}]}
-
-        batch_conn = mock_api_client.get_connection().batches
-        batch_conn.post.side_effect = AssertCalledWithBatchRequest(self, {
-            'label': BAI2_STMT_LABEL,
-            'transactions': [t['id'] for t in test_data['results']]
-        })
+        _, test_data = mock_test_transactions(mock_api_client)
+        mock_balance(mock_api_client)
+        batch_conn = mock_batch(self, mock_api_client, test_data)
 
         _, bai2_file = generate_bank_statement(self.get_request(),
                                                datetime.now().date())
@@ -67,20 +85,9 @@ class BankStatementGenerationTestCase(SimpleTestCase):
         )
 
     def test_control_totals_correct(self, mock_api_client):
-        test_data = get_test_transactions_for_stmt()
-
-        conn = mock_api_client.get_connection().bank_admin.transactions
-        conn.get.return_value = test_data
-
-        balance_conn = mock_api_client.get_connection().balances
-        balance_conn.get.return_value = {'count': 1,
-                                         'results': [{'closing_balance': 20000}]}
-
-        batch_conn = mock_api_client.get_connection().batches
-        batch_conn.post.side_effect = AssertCalledWithBatchRequest(self, {
-            'label': BAI2_STMT_LABEL,
-            'transactions': [t['id'] for t in test_data['results']]
-        })
+        _, test_data = mock_test_transactions(mock_api_client)
+        mock_balance(mock_api_client)
+        batch_conn = mock_batch(self, mock_api_client, test_data)
 
         _, bai2_file = generate_bank_statement(self.get_request(),
                                                datetime.now().date())
@@ -124,34 +131,35 @@ class BankStatementGenerationTestCase(SimpleTestCase):
             expected_control_total
         )
 
-    def test_reconciles_date(self, mock_api_client):
-        test_data = get_test_transactions_for_stmt()
-
-        conn = mock_api_client.get_connection().bank_admin.transactions
-        conn.get.return_value = test_data
-
-        batch_conn = mock_api_client.get_connection().batches
-        batch_conn.post.side_effect = AssertCalledWithBatchRequest(self, {
-            'label': BAI2_STMT_LABEL,
-            'transactions': [t['id'] for t in test_data['results']]
-        })
+    def test_reference_overwritten_for_credit_and_not_debit(self, mock_api_client):
+        _, test_data = mock_test_transactions(mock_api_client)
+        mock_balance(mock_api_client)
 
         today = datetime.now().date()
         _, bai2_file = generate_bank_statement(self.get_request(),
                                                today)
-        self.assertTrue(batch_conn.post.side_effect.called)
+
+        parsed_file = bai2.parse_from_string(bai2_file, check_integrity=True)
+
+        account = parsed_file.children[0].children[0]
+        for record in account.children:
+            if record.type_code == TypeCodes['399']:
+                self.assertTrue(record.text != ORIGINAL_REF)
+            else:
+                self.assertTrue(record.text == ORIGINAL_REF)
+
+    def test_reconciles_date(self, mock_api_client):
+        conn, test_data = mock_test_transactions(mock_api_client)
+
+        today = datetime.now().date()
+        _, bai2_file = generate_bank_statement(self.get_request(),
+                                               today)
 
         conn.reconcile.post.assert_called_with({'date': today.isoformat()})
 
     def test_posts_new_balance(self, mock_api_client):
-        test_data = get_test_transactions()
-
-        conn = mock_api_client.get_connection().bank_admin.transactions
-        conn.get.return_value = test_data
-
-        balance_conn = mock_api_client.get_connection().balances
-        balance_conn.get.return_value = {'count': 1,
-                                         'results': [{'closing_balance': 20000}]}
+        _, test_data = mock_test_transactions(mock_api_client)
+        balance_conn = mock_balance(mock_api_client)
 
         today = datetime.now().date()
         _, bai2_file = generate_bank_statement(self.get_request(),

--- a/mtp_bank_admin/apps/bank_admin/tests/test_views.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_views.py
@@ -11,7 +11,7 @@ from moj_auth.tests.utils import generate_tokens
 from moj_auth.exceptions import Unauthorized
 
 from . import get_test_transactions, NO_TRANSACTIONS
-from .test_refund import REFUND_TRANSACTIONS
+from .test_refund import REFUND_TRANSACTIONS, get_base_ref
 from ..types import PaymentType
 from .. import ACCESSPAY_LABEL
 
@@ -117,9 +117,10 @@ class DownloadRefundFileViewTestCase(BankAdminViewTestCase):
         self.assertEqual(200, response.status_code)
         self.assertEqual('text/csv', response['Content-Type'])
         self.assertEqual(
-            bytes(('111111,22222222,John Doe,25.68,%(ref)s\r\n' +
-                   '999999,33333333,Joe Bloggs,18.72,%(ref)s\r\n')
-                  % {'ref': settings.REFUND_REFERENCE}, 'utf8'),
+            bytes(('111111,22222222,John Doe,25.68,%(ref_a)s\r\n' +
+                   '999999,33333333,Joe Bloggs,18.72,%(ref_b)s\r\n')
+                  % {'ref_a': get_base_ref() + '00001',
+                     'ref_b': get_base_ref() + '00002'}, 'utf8'),
             response.content)
 
     @mock.patch('bank_admin.refund.api_client')
@@ -138,9 +139,10 @@ class DownloadRefundFileViewTestCase(BankAdminViewTestCase):
         self.assertEqual(200, response.status_code)
         self.assertEqual('text/csv', response['Content-Type'])
         self.assertEqual(
-            bytes(('111111,22222222,John Doe,25.68,%(ref)s\r\n' +
-                   '999999,33333333,Joe Bloggs,18.72,%(ref)s\r\n')
-                  % {'ref': settings.REFUND_REFERENCE}, 'utf8'),
+            bytes(('111111,22222222,John Doe,25.68,%(ref_a)s\r\n' +
+                   '999999,33333333,Joe Bloggs,18.72,%(ref_b)s\r\n')
+                  % {'ref_a': get_base_ref() + '00001',
+                     'ref_b': get_base_ref() + '00002'}, 'utf8'),
             response.content)
 
 

--- a/mtp_bank_admin/settings/base.py
+++ b/mtp_bank_admin/settings/base.py
@@ -202,7 +202,7 @@ OAUTHLIB_INSECURE_TRANSPORT = True
 
 GOOGLE_ANALYTICS_ID = os.environ.get('GOOGLE_ANALYTICS_ID', None)
 
-REFUND_REFERENCE = 'Payment refunded'
+REFUND_REFERENCE = 'Refund %s_%s'
 REFUND_OUTPUT_FILENAME = 'mtp_accesspay_%d%m%y.csv'
 
 ADI_TEMPLATE_FILEPATH = 'local_files/adi_template.xlsx'


### PR DESCRIPTION
Although debits that appear in the statement are not automatically
reconciled, staff will wish to match them up against the corresponding
invalid credit. For this reason we include the date of the refund
and its ref_code in the refund file, which is then displayed in
the debit line in the subsequent BAI.