### PR TITLE
Alter file date formats to match those desired by SSCL

### DIFF
--- a/mtp_bank_admin/apps/bank_admin/statement.py
+++ b/mtp_bank_admin/apps/bank_admin/statement.py
@@ -124,5 +124,5 @@ def generate_bank_statement(request, receipt_date):
                         [t['id'] for t in transactions])
     update_new_balance(request, receipt_date, closing_balance)
 
-    return (datetime.date.today().strftime(settings.BANK_STMT_OUTPUT_FILENAME),
+    return (receipt_date.strftime(settings.BANK_STMT_OUTPUT_FILENAME),
             output)

--- a/mtp_bank_admin/settings/base.py
+++ b/mtp_bank_admin/settings/base.py
@@ -207,8 +207,8 @@ REFUND_REFERENCE = 'Refund %s_%s'
 REFUND_OUTPUT_FILENAME = 'mtp_accesspay_%d%m%y.csv'
 
 ADI_TEMPLATE_FILEPATH = 'local_files/adi_template.xlsx'
-ADI_PAYMENT_OUTPUT_FILENAME = 'adi_credit_file_%d%m%y.xlsx'
-ADI_REFUND_OUTPUT_FILENAME = 'adi_refund_file_%d%m%y.xlsx'
+ADI_PAYMENT_OUTPUT_FILENAME = 'adi_credit_file_%y%m%d.xlsx'
+ADI_REFUND_OUTPUT_FILENAME = 'adi_refund_file_%y%m%d.xlsx'
 
 BANK_STMT_SENDER_ID = os.environ.get('BANK_STMT_SENDER_ID', '')
 BANK_STMT_RECEIVER_ID = os.environ.get('BANK_STMT_RECEIVER_ID', '')


### PR DESCRIPTION
Changes the date format for generated ADI files and alters
the date in the bank statement filename to be the date of
the transactions rather than the date on which it was generated.