### PR TITLE
Use the sender_roll_number as the refund payee reference when present

### DIFF
--- a/mtp_bank_admin/apps/bank_admin/refund.py
+++ b/mtp_bank_admin/apps/bank_admin/refund.py
@@ -1,6 +1,6 @@
 import csv
 import io
-from datetime import date
+from datetime import date, datetime
 from decimal import Decimal
 
 from django.conf import settings
@@ -70,6 +70,10 @@ def generate_refund_file(request, transactions):
 
 
 def refund_reference(transaction):
-    date_part = date.today().strftime('%d%m')
-    ref_part = transaction['ref_code'][1:]
-    return settings.REFUND_REFERENCE % (date_part, ref_part)
+    if transaction.get('sender_roll_number'):
+        return transaction['sender_roll_number']
+    else:
+        receipt_date = datetime.strptime(transaction['received_at'][:10], '%Y-%m-%d')
+        date_part = receipt_date.strftime('%d%m')
+        ref_part = transaction['ref_code'][1:]
+        return settings.REFUND_REFERENCE % (date_part, ref_part)

--- a/mtp_bank_admin/apps/bank_admin/tests/test_views.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_views.py
@@ -11,7 +11,7 @@ from moj_auth.tests.utils import generate_tokens
 from moj_auth.exceptions import Unauthorized
 
 from . import get_test_transactions, NO_TRANSACTIONS
-from .test_refund import REFUND_TRANSACTIONS, get_base_ref
+from .test_refund import REFUND_TRANSACTIONS, expected_output
 from ..types import PaymentType
 from .. import ACCESSPAY_LABEL
 
@@ -117,11 +117,9 @@ class DownloadRefundFileViewTestCase(BankAdminViewTestCase):
         self.assertEqual(200, response.status_code)
         self.assertEqual('text/csv', response['Content-Type'])
         self.assertEqual(
-            bytes(('111111,22222222,John Doe,25.68,%(ref_a)s\r\n' +
-                   '999999,33333333,Joe Bloggs,18.72,%(ref_b)s\r\n')
-                  % {'ref_a': get_base_ref() + '00001',
-                     'ref_b': get_base_ref() + '00002'}, 'utf8'),
-            response.content)
+            bytes(expected_output(), 'utf8'),
+            response.content
+        )
 
     @mock.patch('bank_admin.refund.api_client')
     @mock.patch('bank_admin.utils.api_client')
@@ -139,11 +137,9 @@ class DownloadRefundFileViewTestCase(BankAdminViewTestCase):
         self.assertEqual(200, response.status_code)
         self.assertEqual('text/csv', response['Content-Type'])
         self.assertEqual(
-            bytes(('111111,22222222,John Doe,25.68,%(ref_a)s\r\n' +
-                   '999999,33333333,Joe Bloggs,18.72,%(ref_b)s\r\n')
-                  % {'ref_a': get_base_ref() + '00001',
-                     'ref_b': get_base_ref() + '00002'}, 'utf8'),
-            response.content)
+            bytes(expected_output(), 'utf8'),
+            response.content
+        )
 
 
 @mock.patch('bank_admin.utils.api_client')


### PR DESCRIPTION
This is required to successfully pay into old-style building society
accounts which all share an account number but which are
distinguished by a roll number.