### PR TITLE
Allow download of previous access pay file from the same link

### DIFF
--- a/mtp_bank_admin/apps/bank_admin/tests/test_functional.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_functional.py
@@ -123,11 +123,10 @@ class DownloadPageTests(FunctionalTestCase):
     def test_checking_download_page(self):
         self.assertIn('Access Pay file – refunds', self.driver.page_source)
         self.assertIn('Download file', self.driver.page_source)
-        self.assertIn('Previous file', self.driver.page_source)
         self.assertIn('ADI Journal – refunds', self.driver.page_source)
         self.assertIn('Download transactions', self.driver.page_source)
         self.assertIn('Previous ADI Journals – refunds', self.driver.page_source)
-        self.assertIn('ADI Journal – payments', self.driver.page_source)
+        self.assertIn('ADI Journal – credits', self.driver.page_source)
         self.assertIn('Bank statement', self.driver.page_source)
         self.assertIn('Download transactions', self.driver.page_source)
         self.assertIn('Previous bank statements', self.driver.page_source)
@@ -153,3 +152,14 @@ class DownloadPageTests(FunctionalTestCase):
         self.assertEqual('block', help_box_contents.value_of_css_property('display'))
         help_box_button.click()
         self.assertEqual('none', help_box_contents.value_of_css_property('display'))
+
+    def test_download_again(self):
+        download_refunds_link = self.driver.find_element_by_xpath('//a[contains(text(), "Download file")]')
+        download_refunds_link.click()
+        self.assertNotIn('The Access Pay file has already been downloaded', self.driver.page_source)
+        download_refunds_link.click()
+        self.assertIn('The Access Pay file has already been downloaded', self.driver.page_source)
+        self.assertEqual(self.driver.current_url, self.live_server_url + '/?redownload_refunds=true')
+        download_refunds_link = self.driver.find_element_by_xpath('//a[contains(text(), "Download file")]')
+        download_refunds_link.click()
+        self.assertIn('The Access Pay file has already been downloaded', self.driver.page_source)

--- a/mtp_bank_admin/apps/bank_admin/tests/test_views.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_views.py
@@ -172,7 +172,7 @@ class DownloadRefundFileErrorViewTestCase(BankAdminViewTestCase):
         )
 
         self.assertContains(response,
-                            _('No new transactions available for refund'),
+                            _('The Access Pay file has already been downloaded'),
                             status_code=200)
 
 

--- a/mtp_bank_admin/apps/bank_admin/urls.py
+++ b/mtp_bank_admin/apps/bank_admin/urls.py
@@ -11,8 +11,6 @@ urlpatterns = [
         name='dashboard'),
     url(r'^refund_pending/download/$', views.download_refund_file,
         name='download_refund_file'),
-    url(r'^previously_refunded/download/$', views.download_previous_refund_file,
-        name='download_previous_refund_file'),
     url(r'^adi/payment/download/$', views.download_adi_payment_file,
         name='download_adi_payment_file'),
     url(r'^adi/refund/download/$', views.download_adi_refund_file,

--- a/mtp_bank_admin/apps/bank_admin/views.py
+++ b/mtp_bank_admin/apps/bank_admin/views.py
@@ -30,8 +30,6 @@ def download_refund_file(request):
                     'username': request.user.username
                 })
             else:
-                messages.add_message(request, messages.ERROR,
-                                     _('No transactions available for refund'))
                 raise EmptyFileError
 
         response = HttpResponse(csvdata, content_type='text/csv')
@@ -39,7 +37,9 @@ def download_refund_file(request):
 
         return response
     except EmptyFileError:
-        pass
+        if redownload_refunds:
+            messages.add_message(request, messages.ERROR,
+                                 _('No transactions available for refund'))
 
     return redirect(reverse_lazy('bank_admin:dashboard') + '?redownload_refunds=true')
 

--- a/mtp_bank_admin/templates/bank_admin/dashboard.html
+++ b/mtp_bank_admin/templates/bank_admin/dashboard.html
@@ -24,7 +24,13 @@
   <section class="ContentBlock">
     <h3>{% trans 'Access Pay file – refunds' %}</h3>
     {% if request.GET.redownload_refunds %}
-      <p>{% trans 'No new transactions available for refund' %}</p>
+      <div class="important">
+        <div class="icon"></div>
+        <div class="message">
+          <p><strong>{% trans 'The Access Pay file has already been downloaded' %}</strong></p>
+          <p>You can still download it but check that refunds are not processed twice</p>
+        </div>
+      </div>
     {% endif %}
     <a href="{% url 'bank_admin:download_refund_file' %}{% if request.GET.redownload_refunds %}?redownload_refunds=true{% endif %}">
       {% now 'd/m/Y' as today %}

--- a/mtp_bank_admin/templates/bank_admin/dashboard.html
+++ b/mtp_bank_admin/templates/bank_admin/dashboard.html
@@ -23,20 +23,13 @@
   {% if perms.transaction.view_bank_details_transaction %}
   <section class="ContentBlock">
     <h3>{% trans 'Access Pay file – refunds' %}</h3>
-    <a href="{% url 'bank_admin:download_refund_file' %}">
+    {% if request.GET.redownload_refunds %}
+      <p>{% trans 'No new transactions available for refund' %}</p>
+    {% endif %}
+    <a href="{% url 'bank_admin:download_refund_file' %}{% if request.GET.redownload_refunds %}?redownload_refunds=true{% endif %}">
       {% now 'd/m/Y' as today %}
       {% blocktrans with date=today %}Download file for {{ date }}{% endblocktrans %}
     </a>
-    <div class="help-box help-box-popup help-box-hidden">
-      <h3><div></div>{% trans 'Previous file' %}</h3>
-      <div class="help-box-contents">
-        <ul>
-          <li><a href="{% url 'bank_admin:download_previous_refund_file' %}">
-            {% trans 'Download previous file' %}
-          </a></li>
-        </ul>
-      </div>
-    </div>
     <hr/>
   </section>
   {% endif %}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "money-to-prisoners-common": "ministryofjustice/money-to-prisoners-common#2.0.7",
+    "money-to-prisoners-common": "ministryofjustice/money-to-prisoners-common#2.2.0",
     "phantomjs": "^1.9.19"
   }
 }


### PR DESCRIPTION
The ability to download the previous file if no new transactions are
available is triggered only after an initial failure and display of
a warning message that the file has already been downloaded.