### PR TITLE
Trigger reconciliation on download of AccessPay file

### DIFF
--- a/mtp_bank_admin/apps/bank_admin/refund.py
+++ b/mtp_bank_admin/apps/bank_admin/refund.py
@@ -9,11 +9,13 @@ from moj_auth.backends import api_client
 from . import ACCESSPAY_LABEL
 from .exceptions import EmptyFileError
 from .utils import (
-    retrieve_all_transactions, create_batch_record, escape_csv_formula, get_next_weekday
+    retrieve_all_transactions, create_batch_record, escape_csv_formula,
+    get_next_weekday, reconcile_for_date
 )
 
 
 def generate_refund_file_for_date(request, receipt_date):
+    reconcile_for_date(request, receipt_date)
     transactions_to_refund = retrieve_all_transactions(
         request,
         status='refund_pending,refunded',

--- a/mtp_bank_admin/apps/bank_admin/tests/test_refund.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_refund.py
@@ -81,6 +81,9 @@ class ValidTransactionsTestCase(SimpleTestCase):
 
         _, csvdata = refund.generate_refund_file_for_date(None, date.today())
 
+        conn.reconcile.post.assert_called_with(
+            {'date': date.today().isoformat()}
+        )
         refund_conn.patch.assert_called_once_with([
             {'id': '3', 'refunded': True},
             {'id': '4', 'refunded': True},


### PR DESCRIPTION
Downloading the AccessPay file will now trigger reconciliation
for that date. This is to ensure that the ref codes used in the
refund file are consistent with those used in the reconciliation
files.