### PR TITLE
Cease updating closing balance on statement download

### DIFF
--- a/mtp_bank_admin/apps/bank_admin/statement.py
+++ b/mtp_bank_admin/apps/bank_admin/statement.py
@@ -4,9 +4,10 @@ from django.conf import settings
 from bai2 import bai2, models, constants
 
 from . import BAI2_STMT_LABEL
-from .utils import retrieve_all_transactions,\
-    create_batch_record, get_daily_file_uid, reconcile_for_date,\
-    retrieve_last_balance, update_new_balance
+from .utils import (
+    retrieve_all_transactions, create_batch_record, get_daily_file_uid,
+    reconcile_for_date, retrieve_last_balance
+)
 
 
 CREDIT_TYPE_CODE = '399'
@@ -116,7 +117,6 @@ def generate_bank_statement(request, receipt_date):
     group.children.append(account)
 
     output = bai2.write(bai2_file, clock_format_for_intra_day=True)
-    update_new_balance(request, receipt_date, closing_balance)
     if len(transactions) > 0:
         create_batch_record(request, BAI2_STMT_LABEL,
                             [t['id'] for t in transactions])

--- a/mtp_bank_admin/apps/bank_admin/tests/test_statement.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_statement.py
@@ -156,24 +156,6 @@ class BankStatementGenerationTestCase(SimpleTestCase):
 
         conn.reconcile.post.assert_called_with({'date': today.isoformat()})
 
-    def test_posts_new_balance(self, mock_api_client):
-        _, test_data = mock_test_transactions(mock_api_client)
-        balance_conn = mock_balance(mock_api_client)
-
-        today = datetime.now().date()
-        _, bai2_file = generate_bank_statement(self.get_request(),
-                                               today)
-
-        closing_balance = 20000
-        for transaction in test_data['results']:
-            if transaction['category'] == 'debit':
-                closing_balance -= transaction['amount']
-            else:
-                closing_balance += transaction['amount']
-
-        balance_conn.post.assert_called_with(
-            {'date': today.isoformat(), 'closing_balance': closing_balance})
-
 
 @mock.patch('mtp_bank_admin.apps.bank_admin.utils.api_client')
 class NoTransactionsTestCase(SimpleTestCase):

--- a/mtp_bank_admin/apps/bank_admin/utils.py
+++ b/mtp_bank_admin/apps/bank_admin/utils.py
@@ -3,7 +3,6 @@ import time
 
 from moj_auth import api_client
 from mtp_utils.api import retrieve_all_pages
-from slumber.exceptions import HttpClientError
 
 
 def retrieve_all_transactions(request, **kwargs):
@@ -43,16 +42,6 @@ def retrieve_last_balance(request, date):
         return response['results'][0]
     else:
         return None
-
-
-def update_new_balance(request, date, closing_balance):
-    client = api_client.get_connection(request)
-    try:
-        client.balances.post({'date': date.isoformat(),
-                              'closing_balance': closing_balance})
-    except HttpClientError:
-        # this is probably fine, just means that balance exists
-        pass
 
 
 def get_daily_file_uid():


### PR DESCRIPTION
The recorded closing balance for the day is now created when the
transactions are uploaded. The statement closing balance is still, however,
created from the transactions and the opening balance (previous closing).
This is to allow for empty statement cases where no transactions were
uploaded for that day, but will still be sufficient to avoid out of
order bugs.