### PR TITLE
Use new transaction endpoint and status types

### DIFF
--- a/mtp_bank_admin/apps/bank_admin/adi.py
+++ b/mtp_bank_admin/apps/bank_admin/adi.py
@@ -112,7 +112,7 @@ def generate_adi_payment_file(request, receipt_date):
     reconcile_for_date(request, receipt_date)
     new_transactions = retrieve_all_transactions(
         request,
-        status='credited,available,locked',
+        status='creditable',
         received_at__gte=receipt_date,
         received_at__lt=(receipt_date + timedelta(days=1))
     )
@@ -156,7 +156,7 @@ def generate_adi_refund_file(request, receipt_date):
     reconcile_for_date(request, receipt_date)
     refunds = retrieve_all_transactions(
         request,
-        status='refunded,refund_pending',
+        status='refundable',
         received_at__gte=receipt_date,
         received_at__lt=(receipt_date + timedelta(days=1))
     )

--- a/mtp_bank_admin/apps/bank_admin/refund.py
+++ b/mtp_bank_admin/apps/bank_admin/refund.py
@@ -18,7 +18,7 @@ def generate_refund_file_for_date(request, receipt_date):
     reconcile_for_date(request, receipt_date)
     transactions_to_refund = retrieve_all_transactions(
         request,
-        status='refund_pending,refunded',
+        status='refundable',
         received_at__gte=receipt_date,
         received_at__lt=(receipt_date + timedelta(days=1))
     )
@@ -31,7 +31,7 @@ def generate_refund_file_for_date(request, receipt_date):
 
     # mark transactions as refunded
     client = api_client.get_connection(request)
-    client.bank_admin.transactions.patch(refunded_transactions)
+    client.transactions.patch(refunded_transactions)
 
     create_batch_record(request, ACCESSPAY_LABEL,
                         [t['id'] for t in transactions_to_refund])

--- a/mtp_bank_admin/apps/bank_admin/tests/test_adi.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_adi.py
@@ -48,7 +48,7 @@ class AdiPaymentFileGenerationTestCase(SimpleTestCase):
     def test_adi_payment_file_generation(self, mock_api_client):
         test_data = get_test_transactions(PaymentType.payment)
 
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.return_value = test_data
 
         filename, exceldata = adi.generate_adi_payment_file(self.get_request(),
@@ -60,7 +60,7 @@ class AdiPaymentFileGenerationTestCase(SimpleTestCase):
     def test_adi_payment_file_debits_match_credit(self, mock_api_client):
         test_data = get_test_transactions(PaymentType.payment)
 
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.return_value = test_data
 
         batch_conn = mock_api_client.get_connection().batches
@@ -93,7 +93,7 @@ class AdiPaymentFileGenerationTestCase(SimpleTestCase):
     def test_adi_payment_file_number_of_payment_rows_correct(self, mock_api_client):
         test_data = get_test_transactions(PaymentType.payment)
 
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.return_value = test_data
 
         batch_conn = mock_api_client.get_connection().batches
@@ -129,7 +129,7 @@ class AdiPaymentFileGenerationTestCase(SimpleTestCase):
     def test_adi_payment_file_credit_sum_correct(self, mock_api_client):
         test_data = get_test_transactions(PaymentType.payment)
 
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.return_value = test_data
 
         batch_conn = mock_api_client.get_connection().batches
@@ -167,7 +167,7 @@ class AdiPaymentFileGenerationTestCase(SimpleTestCase):
         self.assertEqual(credits_checked, len(TEST_PRISONS))
 
     def test_no_transactions_raises_error(self, mock_api_client):
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.return_value = NO_TRANSACTIONS
 
         try:
@@ -180,7 +180,7 @@ class AdiPaymentFileGenerationTestCase(SimpleTestCase):
     def test_adi_payment_file_reconciles_date(self, mock_api_client):
         test_data = get_test_transactions(PaymentType.payment)
 
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.return_value = test_data
 
         batch_conn = mock_api_client.get_connection().batches
@@ -213,7 +213,7 @@ class AdiRefundFileGenerationTestCase(SimpleTestCase):
     def test_adi_refund_file_generation(self, mock_api_client):
         test_data = get_test_transactions(PaymentType.refund)
 
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.return_value = test_data
 
         filename, exceldata = adi.generate_adi_refund_file(self.get_request(),
@@ -225,7 +225,7 @@ class AdiRefundFileGenerationTestCase(SimpleTestCase):
     def test_adi_refund_file_debits_match_credit(self, mock_api_client):
         test_data = get_test_transactions(PaymentType.refund)
 
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.return_value = test_data
 
         batch_conn = mock_api_client.get_connection().batches
@@ -258,7 +258,7 @@ class AdiRefundFileGenerationTestCase(SimpleTestCase):
     def test_adi_refund_file_number_of_payment_rows_correct(self, mock_api_client):
         test_data = get_test_transactions(PaymentType.refund)
 
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.return_value = test_data
 
         batch_conn = mock_api_client.get_connection().batches
@@ -294,7 +294,7 @@ class AdiRefundFileGenerationTestCase(SimpleTestCase):
     def test_adi_refund_file_credit_sum_correct(self, mock_api_client):
         test_data = get_test_transactions(PaymentType.refund)
 
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.return_value = test_data
 
         batch_conn = mock_api_client.get_connection().batches
@@ -326,7 +326,7 @@ class AdiRefundFileGenerationTestCase(SimpleTestCase):
         self.assertTrue(credit_checked)
 
     def test_no_transactions_raises_error(self, mock_api_client):
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.return_value = NO_TRANSACTIONS
 
         try:
@@ -339,7 +339,7 @@ class AdiRefundFileGenerationTestCase(SimpleTestCase):
     def test_adi_refund_file_reconciles_date(self, mock_api_client):
         test_data = get_test_transactions(PaymentType.refund)
 
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.return_value = test_data
 
         batch_conn = mock_api_client.get_connection().batches

--- a/mtp_bank_admin/apps/bank_admin/tests/test_refund.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_refund.py
@@ -73,10 +73,10 @@ def get_base_ref():
 class ValidTransactionsTestCase(SimpleTestCase):
 
     def test_generate_refund_file(self, mock_api_client, mock_refund_api_client):
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.side_effect = REFUND_TRANSACTIONS
 
-        refund_conn = mock_refund_api_client.get_connection().bank_admin.transactions
+        refund_conn = mock_refund_api_client.get_connection().transactions
         batch_conn = mock_api_client.get_connection().batches
 
         _, csvdata = refund.generate_refund_file_for_date(None, date.today())
@@ -103,7 +103,7 @@ class ValidTransactionsTestCase(SimpleTestCase):
         )
         naughty_transactions[1]['results'][0]['sender_name'] = ('=1+2')
 
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.side_effect = naughty_transactions
 
         _, csvdata = refund.generate_refund_file_for_date(None, date.today())
@@ -124,10 +124,10 @@ class NoTransactionsTestCase(SimpleTestCase):
 
     def test_generate_refund_file_raises_error(self, mock_api_client,
                                                mock_refund_api_client):
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.return_value = NO_TRANSACTIONS
 
-        refund_conn = mock_refund_api_client.get_connection().bank_admin.transactions
+        refund_conn = mock_refund_api_client.get_connection().transactions
 
         try:
             _, csvdata = refund.generate_refund_file_for_date(None, date.today())

--- a/mtp_bank_admin/apps/bank_admin/tests/test_statement.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_statement.py
@@ -29,7 +29,7 @@ def get_test_transactions_for_stmt(count=20):
 
 def mock_test_transactions(mock_api_client):
     test_data = get_test_transactions_for_stmt()
-    conn = mock_api_client.get_connection().bank_admin.transactions
+    conn = mock_api_client.get_connection().transactions
     conn.get.return_value = test_data
 
     return conn, test_data
@@ -170,7 +170,7 @@ class NoTransactionsTestCase(SimpleTestCase):
         )
 
     def test_empty_statement_generated(self, mock_api_client):
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.return_value = NO_TRANSACTIONS
         mock_balance(mock_api_client)
 

--- a/mtp_bank_admin/apps/bank_admin/tests/test_views.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_views.py
@@ -109,7 +109,7 @@ class DownloadRefundFileViewTestCase(BankAdminViewTestCase):
     def test_download_refund_file(self, mock_api_client, mock_refund_api_client):
         self.login()
 
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.side_effect = REFUND_TRANSACTIONS
 
         response = self.client.get(reverse('bank_admin:download_refund_file') +
@@ -127,7 +127,7 @@ class DownloadRefundFileViewTestCase(BankAdminViewTestCase):
     def test_accesspay_queries_by_date(self, mock_api_client, mock_refund_api_client):
         self.login()
 
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.side_effect = {
             'count': 1,
             'results': [{
@@ -152,7 +152,7 @@ class DownloadRefundFileViewTestCase(BankAdminViewTestCase):
         conn.get.assert_called_with(
             limit=settings.REQUEST_PAGE_SIZE,
             offset=0,
-            status='refund_pending,refunded',
+            status='refundable',
             received_at__gte=datetime.date(2014, 11, 12),
             received_at__lt=datetime.date(2014, 11, 13)
         )
@@ -165,7 +165,7 @@ class DownloadRefundFileErrorViewTestCase(BankAdminViewTestCase):
     def test_download_refund_file_unauthorized(self, auth_api_client, mock_api_client):
         self.login()
 
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.side_effect = Unauthorized()
 
         response = self.client.get(reverse('bank_admin:download_refund_file') +
@@ -177,7 +177,7 @@ class DownloadRefundFileErrorViewTestCase(BankAdminViewTestCase):
     def test_download_refund_file_no_transactions_error_message(self, mock_api_client):
         self.login()
 
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.return_value = NO_TRANSACTIONS
 
         response = self.client.get(
@@ -207,7 +207,7 @@ class DownloadAdiFileViewTestCase(BankAdminViewTestCase):
     def test_download_adi_payment_file(self, mock_api_client):
         self.login()
 
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.return_value = get_test_transactions(PaymentType.payment)
 
         response = self.client.get(reverse('bank_admin:download_adi_payment_file') +
@@ -220,7 +220,7 @@ class DownloadAdiFileViewTestCase(BankAdminViewTestCase):
     def test_payments_queries_by_date(self, mock_api_client):
         self.login()
 
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.return_value = get_test_transactions(PaymentType.payment)
 
         self.client.get(
@@ -231,7 +231,7 @@ class DownloadAdiFileViewTestCase(BankAdminViewTestCase):
         conn.get.assert_called_with(
             limit=settings.REQUEST_PAGE_SIZE,
             offset=0,
-            status='credited,available,locked',
+            status='creditable',
             received_at__gte=datetime.date(2014, 11, 12),
             received_at__lt=datetime.date(2014, 11, 13)
         )
@@ -240,7 +240,7 @@ class DownloadAdiFileViewTestCase(BankAdminViewTestCase):
     def test_download_adi_refund_file(self, mock_api_client):
         self.login()
 
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.return_value = get_test_transactions(PaymentType.refund)
 
         response = self.client.get(reverse('bank_admin:download_adi_refund_file') +
@@ -253,7 +253,7 @@ class DownloadAdiFileViewTestCase(BankAdminViewTestCase):
     def test_refunds_queries_by_date(self, mock_api_client):
         self.login()
 
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.return_value = get_test_transactions(PaymentType.refund)
 
         self.client.get(
@@ -264,7 +264,7 @@ class DownloadAdiFileViewTestCase(BankAdminViewTestCase):
         conn.get.assert_called_with(
             limit=settings.REQUEST_PAGE_SIZE,
             offset=0,
-            status='refunded,refund_pending',
+            status='refundable',
             received_at__gte=datetime.date(2014, 11, 12),
             received_at__lt=datetime.date(2014, 11, 13)
         )
@@ -277,7 +277,7 @@ class DownloadAdiFileErrorViewTestCase(BankAdminViewTestCase):
     def test_download_adi_payment_file_unauthorized(self, auth_api_client, mock_api_client):
         self.login()
 
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.side_effect = Unauthorized()
 
         response = self.client.get(reverse('bank_admin:download_adi_payment_file') +
@@ -290,7 +290,7 @@ class DownloadAdiFileErrorViewTestCase(BankAdminViewTestCase):
     def test_download_adi_refund_file_unauthorized(self, auth_api_client, mock_api_client):
         self.login()
 
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.side_effect = Unauthorized()
 
         response = self.client.get(reverse('bank_admin:download_adi_refund_file') +
@@ -302,7 +302,7 @@ class DownloadAdiFileErrorViewTestCase(BankAdminViewTestCase):
     def test_download_adi_payment_file_no_transactions_error_message(self, mock_api_client):
         self.login()
 
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.return_value = NO_TRANSACTIONS
 
         response = self.client.get(reverse('bank_admin:download_adi_payment_file') +
@@ -316,7 +316,7 @@ class DownloadAdiFileErrorViewTestCase(BankAdminViewTestCase):
     def test_download_adi_refund_file_no_transactions_error_message(self, mock_api_client):
         self.login()
 
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.return_value = NO_TRANSACTIONS
 
         response = self.client.get(reverse('bank_admin:download_adi_refund_file') +
@@ -386,7 +386,7 @@ class DownloadBankStatementViewTestCase(BankAdminViewTestCase):
     def test_download_bank_statement(self, mock_api_client):
         self.login()
 
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.return_value = get_test_transactions()
 
         response = self.client.get(reverse('bank_admin:download_bank_statement') +
@@ -399,7 +399,7 @@ class DownloadBankStatementViewTestCase(BankAdminViewTestCase):
     def test_bank_statement_queries_by_date(self, mock_api_client):
         self.login()
 
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.return_value = get_test_transactions()
 
         self.client.get(
@@ -422,7 +422,7 @@ class DownloadBankStatementErrorViewTestCase(BankAdminViewTestCase):
     def test_unauthorized(self, auth_api_client, mock_api_client):
         self.login()
 
-        conn = mock_api_client.get_connection().bank_admin.transactions
+        conn = mock_api_client.get_connection().transactions
         conn.get.side_effect = Unauthorized()
 
         response = self.client.get(reverse('bank_admin:download_bank_statement') +

--- a/mtp_bank_admin/apps/bank_admin/utils.py
+++ b/mtp_bank_admin/apps/bank_admin/utils.py
@@ -6,7 +6,7 @@ from mtp_common.api import retrieve_all_pages
 
 
 def retrieve_all_transactions(request, **kwargs):
-    endpoint = api_client.get_connection(request).bank_admin.transactions.get
+    endpoint = api_client.get_connection(request).transactions.get
     return retrieve_all_pages(endpoint, **kwargs)
 
 
@@ -30,7 +30,7 @@ def get_last_batch(request, label):
 def reconcile_for_date(request, date):
     if date:
         client = api_client.get_connection(request)
-        client.bank_admin.transactions.reconcile.post({
+        client.transactions.reconcile.post({
             'date': date.isoformat(),
         })
 


### PR DESCRIPTION
This is to reflect the changes in the API refactor. Client changes
are minimal.