### PR TITLE
remove Mojular:

### DIFF
--- a/find_common.py
+++ b/find_common.py
@@ -1,2 +1,5 @@
-import pkg_resources
-print(pkg_resources.get_distribution('money-to-prisoners-common').location)
+try:
+    import pkg_resources
+    print(pkg_resources.get_distribution('money-to-prisoners-common').location)
+except Exception:
+    pass

--- a/mtp_bank_admin/assets-src/javascripts/main.js
+++ b/mtp_bank_admin/assets-src/javascripts/main.js
@@ -2,20 +2,6 @@
 
 (function() {
   'use strict';
-
-  var Mojular = require('mojular');
-
-  Mojular
-    .use([
-      require('mojular-govuk-elements'),
-      require('mojular-moj-elements'),
-      require('dialog'),
-      require('messages'),
-      require('print'),
-      require('polyfills'),
-      require('unload'),
-      require('help-popup')
-    ])
-    .init();
-
+  require('analytics').Analytics.init();
+  require('help-popup').HelpPopup.init();
 }());

--- a/mtp_bank_admin/assets-src/stylesheets/app-ie6.scss
+++ b/mtp_bank_admin/assets-src/stylesheets/app-ie6.scss
@@ -1,0 +1,7 @@
+@charset 'UTF-8';
+
+$is-ie: true;
+$ie-version: 6;
+$mobile-ie6: false;
+
+@import 'app';

--- a/mtp_bank_admin/assets-src/stylesheets/app-ie7.scss
+++ b/mtp_bank_admin/assets-src/stylesheets/app-ie7.scss
@@ -1,0 +1,6 @@
+@charset 'UTF-8';
+
+$is-ie: true;
+$ie-version: 7;
+
+@import 'app';

--- a/mtp_bank_admin/assets-src/stylesheets/app-ie8.scss
+++ b/mtp_bank_admin/assets-src/stylesheets/app-ie8.scss
@@ -1,0 +1,6 @@
+@charset 'UTF-8';
+
+$is-ie: true;
+$ie-version: 8;
+
+@import 'app';

--- a/mtp_bank_admin/assets-src/stylesheets/app.scss
+++ b/mtp_bank_admin/assets-src/stylesheets/app.scss
@@ -26,3 +26,7 @@ $images-dir: '/static/images/';
     border-bottom: 1px solid $panel-colour;
   }
 }
+
+form .form-group .form-hint {
+  margin-top: 0;
+}

--- a/mtp_bank_admin/settings/base.py
+++ b/mtp_bank_admin/settings/base.py
@@ -93,8 +93,8 @@ TEMPLATES = [
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [
             get_project_dir('templates'),
-            get_project_dir('node_modules'),
-            get_project_dir('../node_modules/mojular-templates'),
+            get_project_dir('assets/templates'),
+            get_project_dir('node_modules')
         ],
         'APP_DIRS': True,
         'OPTIONS': {

--- a/mtp_bank_admin/settings/docker.py
+++ b/mtp_bank_admin/settings/docker.py
@@ -2,6 +2,7 @@
 Docker settings
 """
 from .base import *  # noqa
+from .base import ENVIRONMENT, os
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')

--- a/mtp_bank_admin/settings/jenkins.py
+++ b/mtp_bank_admin/settings/jenkins.py
@@ -1,4 +1,5 @@
 from .base import *  # noqa
+from .base import INSTALLED_APPS
 
 
 INSTALLED_APPS += (

--- a/mtp_bank_admin/templates/bank_admin/dashboard.html
+++ b/mtp_bank_admin/templates/bank_admin/dashboard.html
@@ -1,10 +1,10 @@
 {% extends 'base.html' %}
 {% load i18n dates %}
 
-{% block content %}
+{% block inner_content %}
   <div class="mtp-compact">
     {% get_preceding_weekdays 3 offset=1 as preceding_days %}
-    <h1>{% trans 'Download files' %}</h1>
+    <h1 class="heading-medium">{% trans 'Download files' %}</h1>
 
     {% include "mtp_common/includes/message_box.html" %}
 
@@ -13,7 +13,7 @@
       <div class="mtp-compact-row-1">
         {% if perms.transaction.view_bank_details_transaction %}
         <section>
-          <h2>{% trans 'Access Pay file – refunds' %}</h2>
+          <h2 class="heading-small">{% trans 'Access Pay file – refunds' %}</h2>
           {% url 'bank_admin:download_refund_file' as base_download_url %}
           {% for day in preceding_days %}
               {% blocktrans with date=day|date:'d/m/Y' asvar download_label %}Download file for {{ date }}{% endblocktrans %}
@@ -29,7 +29,7 @@
             <div class="help-box-title" aria-controls="previous-ap-refunds" aria-expanded="true" role="heading">
               <div></div><a href="#">{% trans 'Previous AccessPay refund files' %}</a>
             </div>
-            <div  class="panel-indent help-box-contents" id="previous-ap-refunds">
+            <div  class="panel help-box-contents" id="previous-ap-refunds">
               <ul>
               {% else %}
                 <li>
@@ -46,7 +46,7 @@
         {% endif %}
 
         <section>
-          <h2>{% trans 'ADI Journal – refunds' %}</h2>
+          <h2 class="heading-small">{% trans 'ADI Journal – refunds' %}</h2>
           {% url 'bank_admin:download_adi_refund_file' as base_download_url %}
           {% for day in preceding_days %}
               {% blocktrans with date=day|date:'d/m/Y' asvar download_label %}Download transactions for {{ date }}{% endblocktrans %}
@@ -62,7 +62,7 @@
             <div class="help-box-title" aria-controls="previous-adi-refunds" aria-expanded="true" role="heading">
               <div></div><a href="#">{% trans 'Previous ADI Journals – refunds' %}</a>
             </div>
-            <div class="panel-indent help-box-contents" id="previous-adi-refunds">
+            <div class="panel help-box-contents" id="previous-adi-refunds">
               <ul>
               {% else %}
                 <li>
@@ -79,7 +79,7 @@
       </div>
       <div class="mtp-compact-row-2">
         <section>
-          <h2>{% trans 'ADI Journal – credits' %}</h2>
+          <h2 class="heading-small">{% trans 'ADI Journal – credits' %}</h2>
           {% url 'bank_admin:download_adi_payment_file' as base_download_url %}
           {% for day in preceding_days %}
             {% blocktrans with date=day|date:'d/m/Y' asvar download_label %}Download transactions for {{ date }}{% endblocktrans %}
@@ -95,7 +95,7 @@
             <div class="help-box-title" aria-controls="previous-adi-journals" aria-expanded="true" role="heading">
               <div></div><a href="#">{% trans 'Previous ADI Journals – credits' %}</a>
             </div>
-            <div class="panel-indent help-box-contents" id="previous-adi-journals">
+            <div class="panel help-box-contents" id="previous-adi-journals">
               <ul>
               {% else %}
                 <li>
@@ -111,7 +111,7 @@
         </section>
 
         <section>
-          <h2>{% trans 'Bank statement' %}</h2>
+          <h2 class="heading-small">{% trans 'Bank statement' %}</h2>
 
           {% url 'bank_admin:download_bank_statement' as base_download_url %}
           {% for day in preceding_days %}
@@ -128,7 +128,7 @@
             <div class="help-box-title" aria-controls="previous-statements" aria-expanded="true" role="heading">
               <div></div><a href="#">{% trans 'Previous bank statements' %}</a>
             </div>
-            <div class="panel-indent help-box-contents" id="previous-statements">
+            <div class="panel help-box-contents" id="previous-statements">
               <ul>
                 {% else %}
                 <li>

--- a/mtp_bank_admin/templates/feedback/submit_feedback.html
+++ b/mtp_bank_admin/templates/feedback/submit_feedback.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 {% load i18n %}
 
-{% block content %}
+{% block inner_content %}
 <header class="ContentHeader">
   <a href="{% url 'bank_admin:dashboard' %}" class="ContentHeader-back">{% trans 'Home' %}</a>
-  <h1>{% trans 'Your feedback' %}</h1>
+  <h1 class="heading-xlarge">{% trans 'Your feedback' %}</h1>
 </header>
 
 <form action="." method="post" id="send-feedback">
@@ -18,7 +18,7 @@
     {% with field=form.ticket_content %}
       <div class="form-group {% if field.errors %}error{% endif %}">
         {% include 'mtp_common/forms/field-label.html' with field=field only %}
-        <p><div class="panel-indent panel-border-wide">
+        <p><div class="panel panel-border-wide">
           {% trans 'Please don’t include bank details or any other personal information.' %}
         </div></p>
         {% include 'mtp_common/forms/field-errors.html' with field=field only %}
@@ -26,7 +26,7 @@
       </div>
     {% endwith %}
 
-    <h2>{% trans 'Do you want a reply?' %}</h2>
+    <h2 class="heading-large">{% trans 'Do you want a reply?' %}</h2>
     <p>{% trans 'Enter your email address if you’d like a reply. We won’t use it for anything else.' %}</p>
 
     {% include 'mtp_common/forms/field.html' with field=form.contact_email only %}

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]==3.8.0
+money-to-prisoners-common[testing]==4.4.0

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,5 +1,5 @@
 # Place docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]==3.8.0
+money-to-prisoners-common[monitoring]==4.4.0
 uWSGI==2.0.12

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+function print_usage {
+    echo "Usage: $0 [options] command"
+    echo "command: serve | watch | docker | update | build | clean | test | start"
+    echo "   -h      print this help"
+    echo "   -c | --common-path <dir>"
+    echo "           Use this directory for the common libraries. Needs -r."
+    echo "   -r | --regenerate-common"
+    echo "           Fetch the common libraries, either from a local directory"
+    echo "           specified with -c, or from pypi is -c is omitted"
+}
+
+# Read command-line options
+while [[ $# > 1 ]]; do
+    key="$1"
+    case $key in
+        -h|--help)
+        print_usage
+        exit
+        ;;
+        -c|--common-path)
+        COMMONPATH="$2"
+        shift
+        ;;
+        -r|--regenerate-common)
+        REGENERATE=YES
+        ;;
+        *)
+        echo "Unknown option $1"
+        exit
+        ;;
+    esac
+    shift
+done
+
+COMMAND=$1
+APP=bank_admin
+VIRTUAL_ENV_DIR=venv
+NODE_MODULES=node_modules
+GOVUK_TEMPLATE_VERSION=0.17.3
+
+case "$COMMAND" in
+    clean)
+        rm -rf $VIRTUAL_ENV_DIR $NODE_MODULES static mtp_$APP/assets mtp_$APP/templates/govuk_template
+        ;;
+    serve | watch | docker | update | build | test | start)
+        PORT=8002
+        BROWSERSYNC_PORT=3002
+        BROWSERSYNC_UI_PORT=3032
+
+        MTP_COMMON_NODE_MODULES=$NODE_MODULES/money-to-prisoners-common
+
+        if [ -z "$VIRTUAL_ENV" ]; then
+          if [ ! -d $VIRTUAL_ENV_DIR ]; then
+            echo "Creating Python virtual environment"
+            virtualenv --python=python3 $VIRTUAL_ENV_DIR >/dev/null
+          fi
+          source $VIRTUAL_ENV_DIR/bin/activate >/dev/null
+        fi
+        PYTHON_BIN=$VIRTUAL_ENV/bin
+        export PYTHON_LIBS=`$PYTHON_BIN/python find_common.py`
+        if [[ ("$REGENERATE" == "YES") || ("$PYTHON_LIBS" == "") ]]; then
+            echo -n "Fetching common resources "
+            if [[ COMMONPATH != "" && -d $COMMONPATH ]]; then
+                echo "from local dir $COMMONPATH"
+                $PYTHON_BIN/pip install -e $COMMONPATH >/dev/null
+            else
+                echo "from pypi"
+                $PYTHON_BIN/pip install money-to-prisoners-common > /dev/null
+            fi
+            export PYTHON_LIBS=`$PYTHON_BIN/python find_common.py`
+        else
+            echo "Common resources found at $PYTHON_LIBS"
+        fi
+        echo "Installing npm front-end assets"
+        npm install >/dev/null
+        npm install `cat $PYTHON_LIBS/mtp_common/npm_requirements.txt` >/dev/null
+        mkdir -p $MTP_COMMON_NODE_MODULES
+        ln -Fs $PYTHON_LIBS/mtp_common/assets $MTP_COMMON_NODE_MODULES
+        make -f $PYTHON_LIBS/mtp_common/Makefile app=$APP port=$PORT browsersync_port=$BROWSERSYNC_PORT browsersync_ui_port=$BROWSERSYNC_UI_PORT $COMMAND
+        ;;
+    *)
+        echo "Unknown command $COMMAND"
+        print_usage
+        ;;
+esac
+

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,11 +4,10 @@ var webpack = require('webpack');
 
 module.exports = {
   entry: {
-    app: './mtp_bank_admin/assets-src/javascripts/main.js',
-    polyfills: ['JSON2', 'html5shiv']
+    app: './mtp_bank_admin/assets-src/javascripts/main.js'
   },
   output: {
-    path: './mtp_bank_admin/assets/scripts',
+    path: './mtp_bank_admin/assets/javascripts',
     filename: '[name].bundle.js'
   },
   module: {
@@ -21,8 +20,7 @@ module.exports = {
   },
   resolve: {
     root: [
-      __dirname + '/node_modules',
-      __dirname + '/node_modules/mojular-moj-elements/node_modules'
+      __dirname + '/node_modules'
     ],
     modulesDirectories: [
       'node_modules',


### PR DESCRIPTION
* use latest common
* require js scripts the standard way
* add stylesheets for old ie versions
* align to govuk visual styles,
* use govuk classes, markup and template
* find new govuk-templates
* make endblocks consistent
* adapt run script and webpack config
* undo copy changes for generic start page