### PR TITLE
Remove 'restrict_applications' argument to login view

### DIFF
--- a/mtp_bank_admin/apps/bank_admin/tests/test_views.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_views.py
@@ -7,7 +7,7 @@ from django.core.urlresolvers import reverse
 from django.utils.encoding import escape_uri_path
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
-from mtp_common.auth.exceptions import Unauthorized
+from mtp_common.auth.exceptions import Unauthorized, Forbidden
 from mtp_common.auth.test_utils import generate_tokens
 
 from . import get_test_transactions, NO_TRANSACTIONS
@@ -53,16 +53,7 @@ class BankAdminViewTestCase(SimpleTestCase):
 class DashboardButtonVisibilityTestCase(BankAdminViewTestCase):
     @mock.patch('mtp_common.auth.backends.api_client')
     def test_cannot_login_without_app_access(self, mock_api_client):
-        mock_api_client.authenticate.return_value = {
-            'pk': 5,
-            'token': generate_tokens(),
-            'user_data': {
-                'first_name': 'Sam',
-                'last_name': 'Hall',
-                'username': 'shall',
-                'permissions': ['transaction.view_bank_details_transaction']
-            }
-        }
+        mock_api_client.authenticate.side_effect = Forbidden
 
         response = self.client.post(
             reverse('login'),

--- a/mtp_bank_admin/urls.py
+++ b/mtp_bank_admin/urls.py
@@ -10,7 +10,6 @@ urlpatterns = [
     url(
         r'^login/$', auth_views.login, {
             'template_name': 'mtp_auth/login.html',
-            'restrict_applications': (settings.API_CLIENT_ID,),
         }, name='login'
     ),
     url(

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]==4.7.0
+money-to-prisoners-common[testing]==4.9.0

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,5 +1,5 @@
 # Place docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]==4.7.0
+money-to-prisoners-common[monitoring]==4.9.0
 uWSGI==2.0.12


### PR DESCRIPTION
This is no longer needed as application restrictions are checked
in the API.