### PR TITLE
Batch batch creation

### DIFF
--- a/conf/uwsgi/bank_admin.ini
+++ b/conf/uwsgi/bank_admin.ini
@@ -15,7 +15,7 @@ env = DJANGO_SETTINGS_MODULE=mtp_%n.settings.docker
 virtualenv = /app/venv
 module = mtp_%n.wsgi:application
 post-buffering = 1
-http-timeout = 20
+http-timeout = 300
 
 ; format uWSGI logs as JSON for ELK
 log-format = {"timestamp_msec": %(tmsecs), "@fields.logger": "uWSGI-Request", "@fields.http_host": "%(host)", "@fields.request_uri": "%(uri)", "@fields.request_method": "%(method)", "@fields.status": %(status), "@fields.response_time": %(micros)}

--- a/mtp_bank_admin/apps/bank_admin/tests/__init__.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/__init__.py
@@ -31,7 +31,7 @@ def get_test_transactions(trans_type=None, count=20):
         transaction['ref_code'] = '9' + str(random.randint(0, 99999)).zfill(5)
         transaction['reference'] = ORIGINAL_REF
         transactions.append(transaction)
-    return {'count': count, 'results': transactions}
+    return {'count': count, 'results': sorted(transactions, key=lambda t: t['id'])}
 
 
 class AssertCalledWithBatchRequest(object):
@@ -50,3 +50,4 @@ class AssertCalledWithBatchRequest(object):
             sorted(actual['transactions']),
             sorted(self.expected['transactions'])
         )
+        return {'id': 1}


### PR DESCRIPTION
The API is unable to handle the creation of a batch of e.g.
20000 transactions in a single request. Instead, the batch is created
and then incrementally updated in REQUEST_PAGE_SIZE batches of
transactions.

Depends on https://github.com/ministryofjustice/money-to-prisoners-api/pull/227