### PR TITLE
Change reconciliation period to extend backwards from reconciliation date

### DIFF
--- a/mtp_bank_admin/apps/bank_admin/adi.py
+++ b/mtp_bank_admin/apps/bank_admin/adi.py
@@ -143,24 +143,24 @@ class AdiJournal(object):
 
 
 def generate_adi_journal(request, receipt_date):
-    reconciliation_date = reconcile_for_date(request, receipt_date)
+    start_date, end_date = reconcile_for_date(request, receipt_date)
 
     credits = retrieve_all_valid_credits(
         request,
-        received_at__gte=receipt_date,
-        received_at__lt=reconciliation_date
+        received_at__gte=start_date,
+        received_at__lt=end_date
     )
     refundable_transactions = retrieve_all_transactions(
         request,
         status='refundable',
-        received_at__gte=receipt_date,
-        received_at__lt=reconciliation_date
+        received_at__gte=start_date,
+        received_at__lt=end_date
     )
     rejected_transactions = retrieve_all_transactions(
         request,
         status='unidentified',
-        received_at__gte=receipt_date,
-        received_at__lt=reconciliation_date
+        received_at__gte=start_date,
+        received_at__lt=end_date
     )
 
     if (len(credits) == 0 and

--- a/mtp_bank_admin/apps/bank_admin/refund.py
+++ b/mtp_bank_admin/apps/bank_admin/refund.py
@@ -17,13 +17,13 @@ logger = logging.getLogger('mtp')
 
 
 def generate_refund_file_for_date(request, receipt_date):
-    reconciliation_date = reconcile_for_date(request, receipt_date)
+    start_date, end_date = reconcile_for_date(request, receipt_date)
 
     transactions_to_refund = retrieve_all_transactions(
         request,
         status='refundable',
-        received_at__gte=receipt_date,
-        received_at__lt=reconciliation_date
+        received_at__gte=start_date,
+        received_at__lt=end_date
     )
 
     filedata = generate_refund_file(request, transactions_to_refund)

--- a/mtp_bank_admin/apps/bank_admin/statement.py
+++ b/mtp_bank_admin/apps/bank_admin/statement.py
@@ -25,12 +25,12 @@ RECORD_LENGTH = 80
 
 
 def generate_bank_statement(request, receipt_date):
-    reconciliation_date = reconcile_for_date(request, receipt_date)
+    start_date, end_date = reconcile_for_date(request, receipt_date)
 
     transactions = retrieve_all_transactions(
         request,
-        received_at__gte=receipt_date,
-        received_at__lt=reconciliation_date
+        received_at__gte=start_date,
+        received_at__lt=end_date
     )
 
     transaction_records = []

--- a/mtp_bank_admin/apps/bank_admin/tests/test_utils.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_utils.py
@@ -25,13 +25,25 @@ class WorkdayCheckerTestCase(SimpleTestCase):
         self.assertTrue(self.checker.is_workday(date(2016, 12, 21)))
 
     def test_next_workday_middle_of_week(self):
-        previous_day = self.checker.get_next_workday(date(2016, 12, 21))
-        self.assertEqual(previous_day, date(2016, 12, 22))
+        next_day = self.checker.get_next_workday(date(2016, 12, 21))
+        self.assertEqual(next_day, date(2016, 12, 22))
 
     def test_next_workday_weekend(self):
-        previous_day = self.checker.get_next_workday(date(2016, 12, 16))
-        self.assertEqual(previous_day, date(2016, 12, 19))
+        next_day = self.checker.get_next_workday(date(2016, 12, 16))
+        self.assertEqual(next_day, date(2016, 12, 19))
 
     def test_next_workday_bank_holidays(self):
-        previous_day = self.checker.get_next_workday(date(2016, 12, 23))
-        self.assertEqual(previous_day, date(2016, 12, 28))
+        next_day = self.checker.get_next_workday(date(2016, 12, 23))
+        self.assertEqual(next_day, date(2016, 12, 28))
+
+    def test_previous_workday_middle_of_week(self):
+        previous_day = self.checker.get_previous_workday(date(2016, 12, 22))
+        self.assertEqual(previous_day, date(2016, 12, 21))
+
+    def test_previous_workday_weekend(self):
+        previous_day = self.checker.get_previous_workday(date(2016, 12, 19))
+        self.assertEqual(previous_day, date(2016, 12, 16))
+
+    def test_previous_workday_bank_holidays(self):
+        previous_day = self.checker.get_previous_workday(date(2016, 12, 28))
+        self.assertEqual(previous_day, date(2016, 12, 23))


### PR DESCRIPTION
This means that the reconciliation period will be from the reconciliation
date back to the previous working day, rather than forwards to the next.
This means that e.g. weekend payments will be included the Monday file
(downloaded on Tuesday) rather than in the Friday file (downloaded on
Monday).