### PR TITLE
Change worldpay batch cutoff to midnight UTC

### DIFF
--- a/mtp_bank_admin/apps/bank_admin/tests/test_adi.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_adi.py
@@ -227,8 +227,8 @@ class AdiPaymentFileGenerationTestCase(SimpleTestCase):
 
         conn = mock_api_client.get_connection().transactions
         conn.reconcile.post.assert_called_with(
-            {'received_at__gte': datetime(2016, 9, 12, 23, 0, tzinfo=utc).isoformat(),
-             'received_at__lt': datetime(2016, 9, 13, 23, 0, tzinfo=utc).isoformat()}
+            {'received_at__gte': datetime(2016, 9, 13, 0, 0, tzinfo=utc).isoformat(),
+             'received_at__lt': datetime(2016, 9, 14, 0, 0, tzinfo=utc).isoformat()}
         )
 
     def test_adi_journal_upload_range_set(self, mock_api_client):

--- a/mtp_bank_admin/apps/bank_admin/tests/test_refund.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_refund.py
@@ -117,8 +117,8 @@ class ValidTransactionsTestCase(RefundFileTestCase):
         )
 
         conn.reconcile.post.assert_called_with(
-            {'received_at__gte': datetime(2016, 9, 12, 23, 0, tzinfo=utc).isoformat(),
-             'received_at__lt': datetime(2016, 9, 13, 23, 0, tzinfo=utc).isoformat()}
+            {'received_at__gte': datetime(2016, 9, 13, 0, 0, tzinfo=utc).isoformat(),
+             'received_at__lt': datetime(2016, 9, 14, 0, 0, tzinfo=utc).isoformat()}
         )
         refund_conn.patch.assert_called_once_with([
             {'id': '3', 'refunded': True},

--- a/mtp_bank_admin/apps/bank_admin/tests/test_statement.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_statement.py
@@ -146,8 +146,8 @@ class BankStatementGenerationTestCase(BankStatementTestCase):
 
         conn = mock_api_client.get_connection().transactions
         conn.reconcile.post.assert_called_with(
-            {'received_at__gte': datetime(2016, 9, 12, 23, 0, tzinfo=utc).isoformat(),
-             'received_at__lt': datetime(2016, 9, 13, 23, 0, tzinfo=utc).isoformat()}
+            {'received_at__gte': datetime(2016, 9, 13, 0, 0, tzinfo=utc).isoformat(),
+             'received_at__lt': datetime(2016, 9, 14, 0, 0, tzinfo=utc).isoformat()}
         )
 
 

--- a/mtp_bank_admin/apps/bank_admin/tests/test_utils.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_utils.py
@@ -16,12 +16,12 @@ class ReconcileForDateTestCase(SimpleTestCase):
 
         conn = mock_api_client.get_connection().transactions
         conn.reconcile.post.assert_called_with(
-            {'received_at__gte': datetime(2016, 9, 14, 23, 0, tzinfo=utc).isoformat(),
-             'received_at__lt': datetime(2016, 9, 15, 23, 0, tzinfo=utc).isoformat()}
+            {'received_at__gte': datetime(2016, 9, 15, 0, 0, tzinfo=utc).isoformat(),
+             'received_at__lt': datetime(2016, 9, 16, 0, 0, tzinfo=utc).isoformat()}
         )
 
-        self.assertEqual(start_date, datetime(2016, 9, 14, 23, 0, tzinfo=utc))
-        self.assertEqual(end_date, datetime(2016, 9, 15, 23, 0, tzinfo=utc))
+        self.assertEqual(start_date, datetime(2016, 9, 15, 0, 0, tzinfo=utc))
+        self.assertEqual(end_date, datetime(2016, 9, 16, 0, 0, tzinfo=utc))
 
     def test_reconciles_weekend(self, mock_api_client):
         start_date, end_date = reconcile_for_date(None, date(2016, 10, 7))
@@ -29,21 +29,21 @@ class ReconcileForDateTestCase(SimpleTestCase):
         conn = mock_api_client.get_connection().transactions
         conn.reconcile.post.assert_has_calls([
             mock.call(
-                {'received_at__gte': datetime(2016, 10, 6, 23, 0, tzinfo=utc).isoformat(),
-                 'received_at__lt': datetime(2016, 10, 7, 23, 0, tzinfo=utc).isoformat()}
+                {'received_at__gte': datetime(2016, 10, 7, 0, 0, tzinfo=utc).isoformat(),
+                 'received_at__lt': datetime(2016, 10, 8, 0, 0, tzinfo=utc).isoformat()}
             ),
             mock.call(
-                {'received_at__gte': datetime(2016, 10, 7, 23, 0, tzinfo=utc).isoformat(),
-                 'received_at__lt': datetime(2016, 10, 8, 23, 0, tzinfo=utc).isoformat()}
+                {'received_at__gte': datetime(2016, 10, 8, 0, 0, tzinfo=utc).isoformat(),
+                 'received_at__lt': datetime(2016, 10, 9, 0, 0, tzinfo=utc).isoformat()}
             ),
             mock.call(
-                {'received_at__gte': datetime(2016, 10, 8, 23, 0, tzinfo=utc).isoformat(),
-                 'received_at__lt': datetime(2016, 10, 9, 23, 0, tzinfo=utc).isoformat()}
+                {'received_at__gte': datetime(2016, 10, 9, 0, 0, tzinfo=utc).isoformat(),
+                 'received_at__lt': datetime(2016, 10, 10, 0, 0, tzinfo=utc).isoformat()}
             )
         ])
 
-        self.assertEqual(start_date, datetime(2016, 10, 6, 23, 0, tzinfo=utc))
-        self.assertEqual(end_date, datetime(2016, 10, 9, 23, 0, tzinfo=utc))
+        self.assertEqual(start_date, datetime(2016, 10, 7, 0, 0, tzinfo=utc))
+        self.assertEqual(end_date, datetime(2016, 10, 10, 0, 0, tzinfo=utc))
 
 
 class WorkdayCheckerTestCase(SimpleTestCase):

--- a/mtp_bank_admin/apps/bank_admin/tests/test_views.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_views.py
@@ -171,8 +171,8 @@ class DownloadRefundFileViewTestCase(BankAdminViewTestCase):
             limit=settings.REQUEST_PAGE_SIZE,
             offset=0,
             status='refundable',
-            received_at__gte=datetime.datetime(2014, 11, 11, 23, 0, tzinfo=utc),
-            received_at__lt=datetime.datetime(2014, 11, 12, 23, 0, tzinfo=utc)
+            received_at__gte=datetime.datetime(2014, 11, 12, 0, 0, tzinfo=utc),
+            received_at__lt=datetime.datetime(2014, 11, 13, 0, 0, tzinfo=utc)
         )
 
 
@@ -258,23 +258,23 @@ class DownloadAdiFileViewTestCase(BankAdminViewTestCase):
             limit=settings.REQUEST_PAGE_SIZE,
             offset=0,
             valid=True,
-            received_at__gte=datetime.datetime(2014, 11, 11, 23, 0, tzinfo=utc),
-            received_at__lt=datetime.datetime(2014, 11, 12, 23, 0, tzinfo=utc)
+            received_at__gte=datetime.datetime(2014, 11, 12, 0, 0, tzinfo=utc),
+            received_at__lt=datetime.datetime(2014, 11, 13, 0, 0, tzinfo=utc)
         )
         conn.transactions.get.assert_has_calls([
             mock.call(
                 limit=settings.REQUEST_PAGE_SIZE,
                 offset=0,
                 status='refundable',
-                received_at__gte=datetime.datetime(2014, 11, 11, 23, 0, tzinfo=utc),
-                received_at__lt=datetime.datetime(2014, 11, 12, 23, 0, tzinfo=utc)
+                received_at__gte=datetime.datetime(2014, 11, 12, 0, 0, tzinfo=utc),
+                received_at__lt=datetime.datetime(2014, 11, 13, 0, 0, tzinfo=utc)
             ),
             mock.call(
                 limit=settings.REQUEST_PAGE_SIZE,
                 offset=0,
                 status='unidentified',
-                received_at__gte=datetime.datetime(2014, 11, 11, 23, 0, tzinfo=utc),
-                received_at__lt=datetime.datetime(2014, 11, 12, 23, 0, tzinfo=utc)
+                received_at__gte=datetime.datetime(2014, 11, 12, 0, 0, tzinfo=utc),
+                received_at__lt=datetime.datetime(2014, 11, 13, 0, 0, tzinfo=utc)
             )
         ])
 
@@ -369,8 +369,8 @@ class DownloadBankStatementViewTestCase(BankAdminViewTestCase):
         conn.get.assert_called_with(
             limit=settings.REQUEST_PAGE_SIZE,
             offset=0,
-            received_at__gte=datetime.datetime(2014, 11, 11, 23, 0, tzinfo=utc),
-            received_at__lt=datetime.datetime(2014, 11, 12, 23, 0, tzinfo=utc)
+            received_at__gte=datetime.datetime(2014, 11, 12, 0, 0, tzinfo=utc),
+            received_at__lt=datetime.datetime(2014, 11, 13, 0, 0, tzinfo=utc)
         )
 
 

--- a/mtp_bank_admin/apps/bank_admin/utils.py
+++ b/mtp_bank_admin/apps/bank_admin/utils.py
@@ -25,7 +25,7 @@ def retrieve_prisons(request):
 
 
 def set_worldpay_cutoff(date):
-    return datetime.combine(date - timedelta(days=1), time(23, 0, tzinfo=utc))
+    return datetime.combine(date, time(0, 0, 0, tzinfo=utc))
 
 
 def reconcile_for_date(request, receipt_date):
@@ -33,7 +33,7 @@ def reconcile_for_date(request, receipt_date):
     start_date = set_worldpay_cutoff(receipt_date)
     end_date = set_worldpay_cutoff(checker.get_next_workday(receipt_date))
 
-    if start_date.date() >= now().date() or end_date.date() >= now().date():
+    if start_date.date() >= now().date() or end_date.date() > now().date():
         raise EarlyReconciliationError
 
     reconciliation_date = start_date


### PR DESCRIPTION
Have confirmed with worldpay that the batch cutoff time is in fact
midnight UTC, not 11pm UTC.