### PR TITLE
Fix template block overriding

### DIFF
--- a/mtp_bank_admin/templates/base.html
+++ b/mtp_bank_admin/templates/base.html
@@ -2,9 +2,10 @@
 {% load i18n %}
 {% load mtp_common %}
 
-{% block main_js %}
+{% block body_end %}
   {{ block.super }}
   {% sentry_js %}
+  <!-- {{ request.resolver_match.url_name }} -->
 {% endblock %}
 
 {% block page_title %}{% trans 'Bank Admin' %}{% endblock %}


### PR DESCRIPTION
`main_js` doesn’t exist anymore