### PR TITLE
Rename service

### DIFF
--- a/mtp_bank_admin/translations/cy/LC_MESSAGES/django.po
+++ b/mtp_bank_admin/translations/cy/LC_MESSAGES/django.po
@@ -1,4 +1,4 @@
-# Send money to a prisoner
+# Prisoner money
 # Copyright (C) Crown copyright (Ministry of Justice)
 msgid ""
 msgstr ""

--- a/mtp_bank_admin/translations/en_GB/LC_MESSAGES/django.po
+++ b/mtp_bank_admin/translations/en_GB/LC_MESSAGES/django.po
@@ -1,4 +1,4 @@
-# Send money to a prisoner
+# Prisoner money
 # Copyright (C) Crown copyright (Ministry of Justice)
 msgid ""
 msgstr ""

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]>=5.26,<5.27
+money-to-prisoners-common[testing]>=5.27,<5.28
 
 mt-940==4.4

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,6 +1,6 @@
 # Place docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]>=5.26,<5.27
+money-to-prisoners-common[monitoring]>=5.27,<5.28
 
 uWSGI==2.0.15


### PR DESCRIPTION
- "Send money to a prisoner" is now "Send money to someone in prison" for consistency
- use "Prisoner money" as the umbrella term in admin views etc