### PR TITLE
Only pre-generate reconciliation files on workdays

### DIFF
--- a/mtp_bank_admin/apps/bank_admin/management/commands/__init__.py
+++ b/mtp_bank_admin/apps/bank_admin/management/commands/__init__.py
@@ -22,6 +22,8 @@ class FileGenerationCommand(BaseCommand):
                 raise CommandError('Date %s cannot be parsed, use YYYY-MM-DD format' % date)
         else:
             workdays = WorkdayChecker()
+            if not workdays.is_workday(date.today()):
+                return
             receipt_date = workdays.get_previous_workday(date.today())
 
         api_session = api_client.get_authenticated_api_session(


### PR DESCRIPTION
This is to avoid marking credits as reconciled (i.e. can no longer
be reallocated) too early, meaning that there are more likely to
be credits that need to be manually credited due to moved
prisoners.