### PR TITLE
Only query for sent or confirmed disbursements

### DIFF
--- a/mtp_bank_admin/apps/bank_admin/disbursements.py
+++ b/mtp_bank_admin/apps/bank_admin/disbursements.py
@@ -48,6 +48,7 @@ def mark_as_sent(api_session, date):
     start_date, end_date = get_start_and_end_date(date)
     disbursements = retrieve_all_disbursements(
         api_session,
+        resolution=['confirmed', 'sent'],
         log__action='confirmed',
         logged_at__gte=start_date,
         logged_at__lt=end_date
@@ -63,6 +64,7 @@ def generate_disbursements_journal(api_session, date):
     start_date, end_date = get_start_and_end_date(date)
     disbursements = retrieve_all_disbursements(
         api_session,
+        resolution=['confirmed', 'sent'],
         log__action='confirmed',
         logged_at__gte=start_date,
         logged_at__lt=end_date

--- a/mtp_bank_admin/apps/bank_admin/tests/test_views.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_views.py
@@ -695,6 +695,7 @@ class DownloadDisbursementsFileViewTestCase(BankAdminViewTestCase):
             dict(
                 limit=str(settings.REQUEST_PAGE_SIZE),
                 offset='0',
+                resolution=['confirmed', 'sent'],
                 log__action='confirmed',
                 logged_at__gte=start_date,
                 logged_at__lt=end_date

--- a/mtp_bank_admin/apps/bank_admin/tests/utils.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/utils.py
@@ -206,7 +206,16 @@ def base_urls_equal(url1, url2):
 
 def get_query_dict(url):
     parsed_url = urlparse(url)
-    return dict(parse_qsl(parsed_url.query))
+    query_params = parse_qsl(parsed_url.query)
+    query_dict = {}
+    for key, value in query_params:
+        if key not in query_dict:
+            query_dict[key] = value
+        elif type(query_dict[key]) == list:
+            query_dict[key].append(value)
+        else:
+            query_dict[key] = [query_dict[key], value]
+    return query_dict
 
 
 @contextmanager


### PR DESCRIPTION
This is to allow for those rare cases where we manually reject a
confirmed payment. We don't want it to appear in the file, even
though it has been confirmed in the past.