### PR TITLE
Fix openpyxl version to <2.5.14 to avoid regression

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@
 # NB: this is not the complete set needed to run the app
 Django>=1.11,<2
 django-widget-tweaks>=1.4,<1.5
-openpyxl>=2.5,<2.6
+openpyxl>=2.5,<2.5.14
 Pillow>=5.3,<6
 transifex-client>=0.12
 django-anymail[mailgun]>=1.3,<2


### PR DESCRIPTION
Causes an erorr when trying to write a file.