### PR TITLE
Zip CSV contents of private estate emails

### DIFF
--- a/mtp_bank_admin/templates/bank_admin/emails/private-estate.html
+++ b/mtp_bank_admin/templates/bank_admin/emails/private-estate.html
@@ -8,7 +8,8 @@
     {% endblocktrans %}
   </p>
   <p>
-    {% trans 'Please upload this file into the CMS and make sure NO credits are rejected.' %}
+    {% trans 'Please unzip this file and upload into the CMS.' %}
+    {% trans 'Make sure NO credits are rejected.' %}
   </p>
   <p>
     {% trans 'If there’s any doubt, put credits on hold or speak with your security department.' %}

--- a/mtp_bank_admin/templates/bank_admin/emails/private-estate.txt
+++ b/mtp_bank_admin/templates/bank_admin/emails/private-estate.txt
@@ -1,7 +1,8 @@
 {% load i18n %}
 {% blocktrans trimmed with date=date|date:'d/m/Y' %}The attached CSV file lists the credits received for {{ prison_name }} on {{ date }} from ‘Send money to someone in prison’.{% endblocktrans %}
 
-{% trans 'Please upload this file into the CMS and make sure NO credits are rejected.' %}
+{% trans 'Please unzip this file and upload into the CMS.' %}
+{% trans 'Make sure NO credits are rejected.' %}
 
 {% trans 'If there’s any doubt, put credits on hold or speak with your security department.' %}
 


### PR DESCRIPTION
… because Mailgun API ignores supplied content type and re-encodes contents incorrectly