### PR TITLE
Allow sending private estate batches to multiple email addresses

### DIFF
--- a/mtp_bank_admin/apps/bank_admin/disbursements.py
+++ b/mtp_bank_admin/apps/bank_admin/disbursements.py
@@ -110,12 +110,16 @@ def add_private_estate_batches(journal, journal_date, prisons, private_estate_ba
         if not private_estate_batch.get('bank_account'):
             logger.error('Private estate batch missing bank account %(prison)s %(date)s' % private_estate_batch)
             continue
+        if not private_estate_batch.get('remittance_emails'):
+            logger.error('Private estate batch missing remittance email addresses %(prison)s' % private_estate_batch)
+            continue
         if not private_estate_batch['total_amount']:
             logger.info('Nothing to transfer to %(prison)s for %(date)s' % private_estate_batch)
             continue
         prison = prisons[private_estate_batch['prison']]
         prison_name = prison.get('short_name') or prison['name']
         bank_account = private_estate_batch['bank_account']
+        recipient_email = private_estate_batch['remittance_emails'][0]
         journal.add_disbursement_row(
             creator='Prisoner money team',
             confirmer='Prisoner money team',
@@ -135,7 +139,7 @@ def add_private_estate_batches(journal, journal_date, prisons, private_estate_ba
             postcode=bank_account['postcode'],
             account_number=bank_account['account_number'],
             sort_code=bank_account['sort_code'],
-            recipient_email=bank_account['remittance_email'],
+            recipient_email=recipient_email,
         )
 
 

--- a/mtp_bank_admin/apps/bank_admin/management/commands/send_private_estate_emails.py
+++ b/mtp_bank_admin/apps/bank_admin/management/commands/send_private_estate_emails.py
@@ -178,7 +178,7 @@ def send_csv(prison, date, batches, csv_contents, total, count):
         ),
         body=text_body.strip('\n'),
         from_email=from_address,
-        to=[some_batch['bank_account']['remittance_email']],
+        to=some_batch['remittance_emails'],
         tags=['private-csv'],
     )
     email.attach_alternative(html_body, mimetype='text/html')

--- a/mtp_bank_admin/apps/bank_admin/tests/test_disbursements.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_disbursements.py
@@ -12,7 +12,7 @@ from openpyxl import load_workbook
 import responses
 
 from .utils import (
-    NO_TRANSACTIONS, mock_list_prisons,
+    NO_TRANSACTIONS, TEST_BANK_ACCOUNT, mock_list_prisons,
     get_test_disbursements, get_private_estate_batches, temp_file, api_url,
     mock_bank_holidays, BankAdminTestCase
 )
@@ -121,7 +121,7 @@ class DisbursementsFileGenerationTestCase(BankAdminTestCase):
             responses.GET,
             api_url('/private-estate-batches/'),
             json={
-                'count': 2,
+                'count': 3,
                 'results': [
                     {'date': '2016-09-13',
                      'prison': 'PR1',
@@ -130,7 +130,13 @@ class DisbursementsFileGenerationTestCase(BankAdminTestCase):
                     {'date': '2016-09-13',
                      'prison': 'PR2',
                      'total_amount': None,
-                     'bank_account': {'account_number': '12345678'}},
+                     'bank_account': TEST_BANK_ACCOUNT,
+                     'remittance_emails': ['private@mtp.local']},
+                    {'date': '2016-09-13',
+                     'prison': 'PR3',
+                     'total_amount': 2000,
+                     'bank_account': TEST_BANK_ACCOUNT,
+                     'remittance_emails': []},
                 ]
             },
             status=200

--- a/mtp_bank_admin/apps/bank_admin/tests/test_private_estate_emails.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_private_estate_emails.py
@@ -10,17 +10,8 @@ from mtp_common.auth.api_client import MoJOAuth2Session
 from mtp_common.auth.test_utils import generate_tokens
 import responses
 
-from bank_admin.tests.utils import TEST_HOLIDAYS, TEST_PRISONS, api_url
+from bank_admin.tests.utils import TEST_HOLIDAYS, TEST_PRISONS, TEST_BANK_ACCOUNT, api_url
 from bank_admin.utils import BANK_HOLIDAY_URL
-
-TEST_BANK_ACCOUNT = {
-    'address_line1': 'line 1',
-    'city': 'city',
-    'postcode': 'post code',
-    'account_number': '12345678',
-    'sort_code': '101010',
-    'remittance_email': 'private@mtp.local',
-}
 
 
 def mock_api_session(mocked_api_session):
@@ -93,22 +84,26 @@ class PrivateEstateEmailTestCase(SimpleTestCase):
                     {'date': '2019-02-15',
                      'prison': 'PR1',
                      'total_amount': 2500,
-                     'bank_account': TEST_BANK_ACCOUNT},
+                     'bank_account': TEST_BANK_ACCOUNT,
+                     'remittance_emails': ['private@mtp.local']},
                     # empty batch, ignored
                     {'date': '2019-02-16',
                      'prison': 'PR1',
                      'total_amount': 0,
-                     'bank_account': TEST_BANK_ACCOUNT},
+                     'bank_account': TEST_BANK_ACCOUNT,
+                     'remittance_emails': ['private@mtp.local']},
                     # ok
                     {'date': '2019-02-17',
                      'prison': 'PR1',
                      'total_amount': 1200,
-                     'bank_account': TEST_BANK_ACCOUNT},
+                     'bank_account': TEST_BANK_ACCOUNT,
+                     'remittance_emails': ['private@mtp.local']},
                     # ok
                     {'date': '2019-02-15',
                      'prison': 'PR2',
                      'total_amount': 2000,
-                     'bank_account': TEST_BANK_ACCOUNT},
+                     'bank_account': TEST_BANK_ACCOUNT,
+                     'remittance_emails': ['private@mtp.local']},
                 ]
             })
             rsps.add(rsps.GET, api_url('prisons/'), json={'count': len(TEST_PRISONS), 'results': TEST_PRISONS})
@@ -224,7 +219,8 @@ class PrivateEstateEmailTestCase(SimpleTestCase):
                     {'date': '2019-02-15',
                      'prison': 'PR1',
                      'total_amount': 2501,
-                     'bank_account': TEST_BANK_ACCOUNT},
+                     'bank_account': TEST_BANK_ACCOUNT,
+                     'remittance_emails': ['private@mtp.local']},
                 ]
             })
             rsps.add(rsps.GET, api_url('prisons/'), json={'count': len(TEST_PRISONS), 'results': TEST_PRISONS})

--- a/mtp_bank_admin/apps/bank_admin/tests/utils.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/utils.py
@@ -33,6 +33,14 @@ ORIGINAL_REF = 'reference'
 SENDER_NAME = 'sender'
 OPENING_BALANCE = 20000
 
+TEST_BANK_ACCOUNT = {
+    'address_line1': 'line 1',
+    'city': 'city',
+    'postcode': 'post code',
+    'account_number': '12345678',
+    'sort_code': '101010',
+}
+
 
 def api_url(path):
     return urljoin(settings.API_URL, path)
@@ -173,8 +181,8 @@ def get_private_estate_batches(date='2016-09-13'):
                 'postcode': 'post code',
                 'account_number': '12345678',
                 'sort_code': '101010',
-                'remittance_email': 'private@mtp.local',
             },
+            'remittance_emails': ['private@mtp.local'],
         }
         for prison in TEST_PRISONS
         if prison['private_estate']


### PR DESCRIPTION
…but remittance slip can only go to one because of SSCL's form restriction