### PR TITLE
Use 4-digit year in private estate CSV batches

### DIFF
--- a/mtp_bank_admin/apps/bank_admin/management/commands/send_private_estate_emails.py
+++ b/mtp_bank_admin/apps/bank_admin/management/commands/send_private_estate_emails.py
@@ -113,7 +113,7 @@ class Command(BaseCommand):
         total = 0
         count = 0
         for batch in batches:
-            csv_batch_date = batch['date'].strftime('%d/%m/%y')
+            csv_batch_date = batch['date'].strftime('%d/%m/%Y')
             credit_list = retrieve_all_pages_for_path(
                 self.api_session,
                 'private-estate-batches/%s/%s/credits/' % (

--- a/mtp_bank_admin/apps/bank_admin/tests/test_private_estate_emails.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_private_estate_emails.py
@@ -172,10 +172,10 @@ class PrivateEstateEmailTestCase(SimpleTestCase):
                 '"Establishment","Date","Prisoner Name","Prisoner Number","TransactionID",'
                 '"Value","Sender","Address",""',
 
-                '"Private 1","15/02/19","JOHN HALLS","A1409AE","100000001",'
+                '"Private 1","15/02/2019","JOHN HALLS","A1409AE","100000001",'
                 '"£25.00","Jilly Halls","Clive House 1 SW1H 9EX",""',
 
-                '"Private 1","17/02/19","JILLY HALLS","A1401AE","100000002",'
+                '"Private 1","17/02/2019","JILLY HALLS","A1401AE","100000002",'
                 '"£12.00","John Halls","Clive House 2 SW1H 9EX",""',
 
                 '"","","","","Total","£37.00","","",""',
@@ -194,10 +194,10 @@ class PrivateEstateEmailTestCase(SimpleTestCase):
                 '"Establishment","Date","Prisoner Name","Prisoner Number","TransactionID",'
                 '"Value","Sender","Address",""',
 
-                '"Private 2","15/02/19","JOHN FREDSON","A1000AA","100000003",'
+                '"Private 2","15/02/2019","JOHN FREDSON","A1000AA","100000003",'
                 '"£7.00","Mary [] Fredson","Clive House 3 SW1H 9EX",""',
 
-                '"Private 2","15/02/19","FRED JOHNSON","A1000BB","100000004",'
+                '"Private 2","15/02/2019","FRED JOHNSON","A1000BB","100000004",'
                 '"£13.00","A JOHNSON","Bank Transfer 102 Petty France London SW1H 9AJ",""',
 
                 '"","","","","Total","£20.00","","",""',


### PR DESCRIPTION
…to try to get the CMS to parse dates accurately

~Don't merge: waiting for more parsing errors and/or confirmation that these date formats parse correctly~ parsing error occurred again