### PR TITLE
Update private estate CSV to be more similar to SPS format

### DIFF
--- a/mtp_bank_admin/apps/bank_admin/management/commands/send_private_estate_emails.py
+++ b/mtp_bank_admin/apps/bank_admin/management/commands/send_private_estate_emails.py
@@ -1,6 +1,5 @@
 import codecs
 import collections
-import csv
 import io
 import logging
 import zipfile
@@ -105,11 +104,7 @@ class Command(BaseCommand):
 
     def prepare_csv(self, batches):
         f = io.StringIO()
-        writer = csv.writer(f, dialect='excel', lineterminator='\r\n', quoting=csv.QUOTE_ALL)
-        writer.writerow([
-            'Establishment', 'Date', 'Prisoner Name', 'Prisoner Number', 'TransactionID', 'Value', 'Sender', 'Address',
-            '',
-        ])
+        f.write('Establishment, Date, Prisoner Name, Prisoner Number, TransactionID, Value, Sender, Address\n')
         total = 0
         count = 0
         for batch in batches:
@@ -125,22 +120,13 @@ class Command(BaseCommand):
             prison_name = batch['prison'].get('short_name') or batch['prison']['name']
             for credit in credit_list:
                 total += credit['amount']
-                writer.writerow([
-                    prison_name,
-                    csv_batch_date,
-                    credit['prisoner_name'],
-                    credit['prisoner_number'],
-                    csv_transaction_id(credit),
-                    format_amount(credit['amount']),
-                    credit.get('sender_name') or 'Unknown sender',
-                    format_address(credit),
-                    ''
-                ])
-        writer.writerow([
-            '', '', '', '',
-            'Total', format_amount(total),
-            '', '', '',
-        ])
+                f.write((
+                    f"{prison_name}, {csv_batch_date},"
+                    f"{credit['prisoner_name']}, {credit['prisoner_number']},"
+                    f" {csv_transaction_id(credit)}, {format_amount(credit['amount'])},"
+                    f"{credit.get('sender_name') or 'Unknown sender'}, {format_address(credit)}, \n"
+                ).replace('"', ''))
+        f.write(f', , , ,Total , {format_amount(total)}, , \n')
         return codecs.encode(f.getvalue(), 'cp1252', errors='ignore'), total, count
 
 

--- a/mtp_bank_admin/apps/bank_admin/management/commands/send_private_estate_emails.py
+++ b/mtp_bank_admin/apps/bank_admin/management/commands/send_private_estate_emails.py
@@ -113,7 +113,7 @@ class Command(BaseCommand):
         total = 0
         count = 0
         for batch in batches:
-            csv_batch_date = batch['date'].strftime('%d/%m/%Y')
+            csv_batch_date = batch['date'].strftime('%d/%m/%y')
             credit_list = retrieve_all_pages_for_path(
                 self.api_session,
                 'private-estate-batches/%s/%s/credits/' % (

--- a/mtp_bank_admin/apps/bank_admin/tests/test_private_estate_emails.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_private_estate_emails.py
@@ -172,10 +172,10 @@ class PrivateEstateEmailTestCase(SimpleTestCase):
                 '"Establishment","Date","Prisoner Name","Prisoner Number","TransactionID",'
                 '"Value","Sender","Address",""',
 
-                '"Private 1","15/02/2019","JOHN HALLS","A1409AE","100000001",'
+                '"Private 1","15/02/19","JOHN HALLS","A1409AE","100000001",'
                 '"£25.00","Jilly Halls","Clive House 1 SW1H 9EX",""',
 
-                '"Private 1","17/02/2019","JILLY HALLS","A1401AE","100000002",'
+                '"Private 1","17/02/19","JILLY HALLS","A1401AE","100000002",'
                 '"£12.00","John Halls","Clive House 2 SW1H 9EX",""',
 
                 '"","","","","Total","£37.00","","",""',
@@ -194,10 +194,10 @@ class PrivateEstateEmailTestCase(SimpleTestCase):
                 '"Establishment","Date","Prisoner Name","Prisoner Number","TransactionID",'
                 '"Value","Sender","Address",""',
 
-                '"Private 2","15/02/2019","JOHN FREDSON","A1000AA","100000003",'
+                '"Private 2","15/02/19","JOHN FREDSON","A1000AA","100000003",'
                 '"£7.00","Mary [] Fredson","Clive House 3 SW1H 9EX",""',
 
-                '"Private 2","15/02/2019","FRED JOHNSON","A1000BB","100000004",'
+                '"Private 2","15/02/19","FRED JOHNSON","A1000BB","100000004",'
                 '"£13.00","A JOHNSON","Bank Transfer 102 Petty France London SW1H 9AJ",""',
 
                 '"","","","","Total","£20.00","","",""',

--- a/mtp_bank_admin/apps/bank_admin/tests/test_private_estate_emails.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_private_estate_emails.py
@@ -149,7 +149,7 @@ class PrivateEstateEmailTestCase(SimpleTestCase):
                      'amount': 1300,
                      'prisoner_name': 'FRED JOHNSON',
                      'prisoner_number': 'A1000BB',
-                     'sender_name': 'A JOHNSON',
+                     'sender_name': 'A "O\'Connell"',  # note quotes
                      'billing_address': None},
                 ],
             })
@@ -167,18 +167,17 @@ class PrivateEstateEmailTestCase(SimpleTestCase):
         self.assertEqual(total, 3700)
         self.assertEqual(count, 2)
         self.assertEqual(
-            csv_contents.decode('cp1252').strip().splitlines(),
+            csv_contents.decode('cp1252').splitlines(),
             [
-                '"Establishment","Date","Prisoner Name","Prisoner Number","TransactionID",'
-                '"Value","Sender","Address",""',
+                'Establishment, Date, Prisoner Name, Prisoner Number, TransactionID, Value, Sender, Address',
 
-                '"Private 1","15/02/19","JOHN HALLS","A1409AE","100000001",'
-                '"£25.00","Jilly Halls","Clive House 1 SW1H 9EX",""',
+                'Private 1, 15/02/19,JOHN HALLS, A1409AE, 100000001,'
+                ' £25.00,Jilly Halls, Clive House 1 SW1H 9EX, ',
 
-                '"Private 1","17/02/19","JILLY HALLS","A1401AE","100000002",'
-                '"£12.00","John Halls","Clive House 2 SW1H 9EX",""',
+                'Private 1, 17/02/19,JILLY HALLS, A1401AE, 100000002,'
+                ' £12.00,John Halls, Clive House 2 SW1H 9EX, ',
 
-                '"","","","","Total","£37.00","","",""',
+                ', , , ,Total , £37.00, , ',
             ]
         )
 
@@ -189,18 +188,17 @@ class PrivateEstateEmailTestCase(SimpleTestCase):
         self.assertEqual(total, 2000)
         self.assertEqual(count, 2)
         self.assertEqual(
-            csv_contents.decode('cp1252').strip().splitlines(),
+            csv_contents.decode('cp1252').splitlines(),
             [
-                '"Establishment","Date","Prisoner Name","Prisoner Number","TransactionID",'
-                '"Value","Sender","Address",""',
+                'Establishment, Date, Prisoner Name, Prisoner Number, TransactionID, Value, Sender, Address',
 
-                '"Private 2","15/02/19","JOHN FREDSON","A1000AA","100000003",'
-                '"£7.00","Mary [] Fredson","Clive House 3 SW1H 9EX",""',
+                'Private 2, 15/02/19,JOHN FREDSON, A1000AA, 100000003,'
+                ' £7.00,Mary [] Fredson, Clive House 3 SW1H 9EX, ',
 
-                '"Private 2","15/02/19","FRED JOHNSON","A1000BB","100000004",'
-                '"£13.00","A JOHNSON","Bank Transfer 102 Petty France London SW1H 9AJ",""',
+                'Private 2, 15/02/19,FRED JOHNSON, A1000BB, 100000004,'
+                ' £13.00,A O\'Connell, Bank Transfer 102 Petty France London SW1H 9AJ, ',
 
-                '"","","","","Total","£20.00","","",""',
+                ', , , ,Total , £20.00, , ',
             ]
         )
 


### PR DESCRIPTION
- do not quote any fields (but strip " just in case)
- use 2-digit year format
- use the same leading and trailing spaces on certain fields
- header row is one field shorter