### PR TITLE
Housekeeping

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ The Bank Admin UI for the Money to Prisoners Project
 
 ## Running locally
 
+It's recommended that you use a python virtual environment to isolate each application.
+Please call this `venv` and make sure it's in the root folder of this application so that
+`mtp_common.test_utils.code_style.CodeStyleTestCase` and the build tasks can find it.
 
 In order to run the application locally, it is necessary to have the API running.
 Please refer to the [money-to-prisoners-api](https://github.com/ministryofjustice/money-to-prisoners-api/) repository.
@@ -16,7 +19,7 @@ Once the API is running locally, run
 ```
 
 This will build everything (which will initially take a while) and run
-the local server at [http://localhost:8001](http://localhost:8001).
+the local server at [http://localhost:8002](http://localhost:8002).
 
 ### Alternative: Docker
 

--- a/mtp_bank_admin/apps/bank_admin/adi.py
+++ b/mtp_bank_admin/apps/bank_admin/adi.py
@@ -48,7 +48,9 @@ class AdiJournal(Journal):
         cell = self.get_cell(field)
         self.journal_ws[cell].number_format = '£#,##0.00_-'
 
-    def lookup(self, field, payment_type, record_type, context={}):
+    def lookup(self, field, payment_type, record_type, context=None):
+        context = context or {}
+
         try:
             value_dict = self.fields[field]['value']
             value = value_dict[payment_type.name][record_type.name]

--- a/mtp_bank_admin/apps/bank_admin/adi.py
+++ b/mtp_bank_admin/apps/bank_admin/adi.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 from datetime import date
 from decimal import Decimal
-import logging
 
 from django.conf import settings
 
@@ -13,8 +12,6 @@ from .utils import (
     reconcile_for_date, retrieve_prisons, get_full_narrative,
     get_or_create_file
 )
-
-logger = logging.getLogger('mtp')
 
 
 def get_adi_journal_file(api_session, receipt_date, user=None):

--- a/mtp_bank_admin/apps/bank_admin/decorators.py
+++ b/mtp_bank_admin/apps/bank_admin/decorators.py
@@ -19,7 +19,7 @@ def filter_by_receipt_date(view_func):
             try:
                 receipt_date = datetime.strptime(receipt_date_str, '%Y-%m-%d').date()
             except ValueError:
-                return HttpResponseBadRequest(_("Invalid format for receipt_date"))
+                return HttpResponseBadRequest(_('Invalid format for receipt_date'))
         else:
             return HttpResponseBadRequest(_("'receipt_date' parameter required"))
         return view_func(request, receipt_date, *args, **kwargs)

--- a/mtp_bank_admin/apps/bank_admin/decorators.py
+++ b/mtp_bank_admin/apps/bank_admin/decorators.py
@@ -5,7 +5,7 @@ from django.core.urlresolvers import reverse_lazy
 from django.contrib import messages
 from django.http import HttpResponseBadRequest
 from django.shortcuts import redirect
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from .exceptions import EmptyFileError, EarlyReconciliationError, UpstreamServiceUnavailable
 

--- a/mtp_bank_admin/apps/bank_admin/management/commands/send_private_estate_emails.py
+++ b/mtp_bank_admin/apps/bank_admin/management/commands/send_private_estate_emails.py
@@ -121,15 +121,15 @@ class Command(BaseCommand):
             for credit in credit_list:
                 total += credit['amount']
                 f.write((
-                    f"{csv_text_value(prison_name)},"
+                    f'{csv_text_value(prison_name)},'
                     f" {csv_batch_date.replace(',', '')},"
                     f"{csv_text_value(credit['prisoner_name'])},"
                     f" {credit['prisoner_number'].replace(',', '')},"
-                    f" {csv_transaction_id(credit)},"
+                    f' {csv_transaction_id(credit)},'
                     f" {format_amount(credit['amount']).replace(',', '')},"
                     f"{csv_text_value(credit.get('sender_name') or 'Unknown sender')},"
-                    f" {csv_text_value(format_address(credit))},"
-                    f" \n"
+                    f' {csv_text_value(format_address(credit))},'
+                    f' \n'
                 ).replace('"', ''))
         f.write(f", , , ,Total , {format_amount(total).replace(',', '')}, , \n")
         return codecs.encode(f.getvalue(), 'cp1252', errors='ignore'), total, count

--- a/mtp_bank_admin/apps/bank_admin/refund.py
+++ b/mtp_bank_admin/apps/bank_admin/refund.py
@@ -2,7 +2,6 @@ import csv
 from datetime import datetime
 from decimal import Decimal
 import io
-import logging
 
 from django.conf import settings
 
@@ -12,8 +11,6 @@ from .utils import (
     retrieve_all_transactions, escape_csv_formula, reconcile_for_date,
     get_or_create_file, get_start_and_end_date
 )
-
-logger = logging.getLogger('mtp')
 
 
 def get_refund_file(api_session, receipt_date, mark_refunded=False):

--- a/mtp_bank_admin/apps/bank_admin/statement.py
+++ b/mtp_bank_admin/apps/bank_admin/statement.py
@@ -1,5 +1,4 @@
 from decimal import Decimal
-import logging
 
 from django.conf import settings
 from django.utils.dateparse import parse_date
@@ -10,8 +9,6 @@ from .utils import (
     retrieve_all_transactions, get_daily_file_uid, get_or_create_file,
     reconcile_for_date, retrieve_last_balance, get_full_narrative
 )
-
-logger = logging.getLogger('mtp')
 
 
 def get_bank_statement_file(api_session, receipt_date):

--- a/mtp_bank_admin/apps/bank_admin/tests/test_private_estate_emails.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_private_estate_emails.py
@@ -196,7 +196,7 @@ class PrivateEstateEmailTestCase(SimpleTestCase):
                 ' £7.00,Mary [] Fredson, Clive House  3 SW1H 9EX, ',
 
                 'Private 2, 15/02/19,FRED JOHNSON, A1000BB, 100000004,'
-                ' £1003.00,A O\'Connell, Bank Transfer 102 Petty France London SW1H 9AJ, ',
+                " £1003.00,A O'Connell, Bank Transfer 102 Petty France London SW1H 9AJ, ",
 
                 ', , , ,Total , £1010.00, , ',
             ]

--- a/mtp_bank_admin/apps/bank_admin/tests/test_refund.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_refund.py
@@ -139,10 +139,10 @@ class ValidTransactionsTestCase(RefundFileTestCase):
         csvdata = self._generate_refund_file(transactions=naughty_transactions)
 
         self.assertEqual(
-            ('''111111,22222222,"'=HYPERLINK(""http://127.0.0.1/?value=""&A1&A1, '''
-             '''""Error: please click for further information"")",25.68,%(ref_a)s\r\n'''
-             '''999999,33333333,'=1+2,18.72,%(ref_b)s\r\n'''
-             '''667788,00000005,Janet Buildingsoc,10.00,A1234567XY\r\n''')
+            ('111111,22222222,"\'=HYPERLINK(""http://127.0.0.1/?value=""&A1&A1, '
+             '""Error: please click for further information"")",25.68,%(ref_a)s\r\n'
+             "999999,33333333,'=1+2,18.72,%(ref_b)s\r\n"
+             '667788,00000005,Janet Buildingsoc,10.00,A1234567XY\r\n')
             % {'ref_a': get_base_ref() + '00001',
                'ref_b': get_base_ref() + '00002'},
             csvdata)

--- a/mtp_bank_admin/apps/bank_admin/tests/test_views.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_views.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.utils.encoding import escape_uri_path
 from django.utils.timezone import utc
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from mtp_common.auth.exceptions import Forbidden
 from mtp_common.auth.test_utils import generate_tokens
 from mtp_common.test_utils import silence_logger

--- a/mtp_bank_admin/apps/bank_admin/tests/test_views.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_views.py
@@ -503,7 +503,7 @@ class DownloadAdiFileErrorViewTestCase(BankAdminViewTestCase):
         )
 
         self.assertContains(response,
-                            _("Invalid format for receipt_date"),
+                            _('Invalid format for receipt_date'),
                             status_code=400)
 
     def test_download_adi_journal_missing_receipt_date(self):
@@ -619,7 +619,7 @@ class DownloadBankStatementErrorViewTestCase(BankAdminViewTestCase):
         )
 
         self.assertContains(response,
-                            _("Invalid format for receipt_date"),
+                            _('Invalid format for receipt_date'),
                             status_code=400)
 
     def test_missing_receipt_date_returns_error(self):
@@ -813,7 +813,7 @@ class DownloadDisbursementsFileErrorViewTestCase(BankAdminViewTestCase):
         )
 
         self.assertContains(response,
-                            _("Invalid format for receipt_date"),
+                            _('Invalid format for receipt_date'),
                             status_code=400)
 
     def test_download_disbursements_missing_receipt_date(self):

--- a/mtp_bank_admin/apps/bank_admin/utils.py
+++ b/mtp_bank_admin/apps/bank_admin/utils.py
@@ -176,7 +176,8 @@ class Journal:
         return '%s%s' % (self.fields[field]['column'],
                          self.current_row)
 
-    def set_field(self, field, value, style=None, extra_style={}):
+    def set_field(self, field, value, style=None, extra_style=None):
+        extra_style = extra_style or {}
         cell = self.get_cell(field)
         self.journal_ws[cell] = value
 
@@ -196,7 +197,9 @@ class Journal:
             )
         return self.journal_ws[cell]
 
-    def lookup(self, field, context={}):
+    def lookup(self, field, context=None):
+        context = context or {}
+
         try:
             value = self.fields[field]['value']
             return value.format(**context)
@@ -215,7 +218,10 @@ def get_cached_file_path(label, date, extension=None):
     return filepath
 
 
-def get_or_create_file(label, date, creation_func, f_args=[], f_kwargs={}, file_extension=None):
+def get_or_create_file(label, date, creation_func, f_args=None, f_kwargs=None, file_extension=None):
+    f_args = f_args or []
+    f_kwargs = f_kwargs or {}
+
     filepath = get_cached_file_path(label, date, extension=file_extension)
     if not os.path.isfile(filepath):
         filedata = creation_func(*f_args, **f_kwargs)


### PR DESCRIPTION
This:

- adds/corrects a few lines in the README
- removes unused lines
- replaces ugettext and ugettext_lazy with the non-prefixed version as they will be eventually deprecated in future Django versions
- makes sure mutable data structures are not used for arg defaults
- makes use of quotes consistent

I'll do the same in all other repos and maybe we can then add `flake8-bugbear` and `flake8-quotes` to mtp_common.