### PR TITLE
Disable management commands in migration mode

### DIFF
--- a/mtp_bank_admin/apps/bank_admin/management/commands/__init__.py
+++ b/mtp_bank_admin/apps/bank_admin/management/commands/__init__.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import date
 
 from django.conf import settings
@@ -6,6 +7,8 @@ from django.utils.dateparse import parse_date
 from mtp_common.auth import api_client
 
 from bank_admin.utils import WorkdayChecker
+
+logger = logging.getLogger('mtp')
 
 
 class FileGenerationCommand(BaseCommand):
@@ -16,6 +19,10 @@ class FileGenerationCommand(BaseCommand):
         parser.add_argument('--date', dest='date', type=str, help='Receipt date')
 
     def handle(self, *args, **options):
+        if settings.CLOUD_PLATFORM_MIGRATION_MODE:
+            logger.warning(f'{self.__class__.__module__} management command will not run in migration mode')
+            return
+
         if options['date']:
             receipt_date = parse_date(options['date'])
             if not receipt_date:

--- a/mtp_bank_admin/apps/bank_admin/management/commands/send_private_estate_emails.py
+++ b/mtp_bank_admin/apps/bank_admin/management/commands/send_private_estate_emails.py
@@ -36,6 +36,10 @@ class Command(BaseCommand):
         )
 
     def handle(self, **options):
+        if settings.CLOUD_PLATFORM_MIGRATION_MODE:
+            logger.warning(f'{self.__class__.__module__} management command will not run in migration mode')
+            return
+
         date = options['date']
         scheduled = options['scheduled']
 

--- a/mtp_bank_admin/apps/bank_admin/tests/test_views.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_views.py
@@ -37,6 +37,16 @@ def mock_missing_download_check():
 
 
 class BankAdminViewTestCase(BankAdminTestCase):
+    def setUp(self):
+        super().setUp()
+        self.notifications_mock = mock.patch('mtp_common.templatetags.mtp_common.notifications_for_request',
+                                             return_value=[])
+        self.notifications_mock.start()
+
+    def tearDown(self):
+        self.notifications_mock.stop()
+        super().tearDown()
+
     @mock.patch('mtp_common.auth.backends.api_client')
     def login(self, mock_api_client):
         mock_api_client.authenticate.return_value = {


### PR DESCRIPTION
to prevent legacy TD apps' cronjobs raising errors