### PR TITLE
Update uWSGI options

### DIFF
--- a/bank_admin.ini
+++ b/bank_admin.ini
@@ -1,29 +1,44 @@
 [uwsgi]
 procname = uwsgi_%n
+die-on-term = 1
+lazy-apps = 0
+vacuum = 1
 
-vhost = true
+master = true
+processes = 2
+enable-threads = true
+threads = 10
+
+chdir = %d
+virtualenv = %d/venv
+module = mtp_%n.wsgi:application
+
 http = :8080
 uid = www-data
 gid = www-data
 chmod-socket = 666
 chown-socket = www-data
-master = true
-enable-threads = true
-processes = 2
-chdir = %d
-virtualenv = %d/venv
-module = mtp_%n.wsgi:application
+
+no-defer-accept = 1
 post-buffering = 1
 buffer-size = 12288
 http-timeout = 300
+http-keepalive = 60
+http-auto-chunked = 1
+add-header = Connection: keep-alive
+
+stats = 127.0.0.1:1717
+# read stats with `uwsgitop` or `uwsgi --connect-and-read 127.0.0.1:1717`
+
+log-x-forwarded-for = 1
+log-zero = 1
+log-ioerror = 1
+# format uWSGI logs as JSON for ELK
+# log-format = {"timestamp": "%(ltime)", "timestamp_msec": %(tmsecs), "@fields.logger": "uWSGI-Request", "@fields.http_host": "%(host)", "@fields.request_uri": "%(uri)", "@fields.request_method": "%(method)", "@fields.status": %(status), "@fields.response_time": %(micros)}
 
 spooler = %d/spooler
 spooler-chdir = %d
 spooler-import = mtp_%n/tasks.py
-
-; format uWSGI logs as JSON for ELK
-log-format = {"timestamp": "%(ltime)", "timestamp_msec": %(tmsecs), "@fields.logger": "uWSGI-Request", "@fields.http_host": "%(host)", "@fields.request_uri": "%(uri)", "@fields.request_method": "%(method)", "@fields.status": %(status), "@fields.response_time": %(micros)}
-
 cron = 40 9 -1 -1 -1 %d/venv/bin/python %d/manage.py create_disbursements_file
 cron = 55 9 -1 -1 -1 %d/venv/bin/python %d/manage.py create_adi_journal_file
 cron = 0 10 -1 -1 -1 %d/venv/bin/python %d/manage.py create_bank_statement_file

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,7 @@
 # Dependencies needed for all environments
 # NB: this is not the complete set needed to run the app
 Django>=1.11,<2
+requests>=2.22,<3
 django-widget-tweaks>=1.4,<1.5
 openpyxl>=2.5,<2.5.14
 Pillow>=5.3,<6


### PR DESCRIPTION
… in the hope of making it work better with keep-alive/connection pooling issues that originate in urllib3.
also:
- simplify logging (CP kibana does not expand json logs into fields)
- add uwsgi stats server (only available inside container)
- hopefully improve k8s/docker compatibility