### PR TITLE
Remove template-deploy artefacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,11 +19,18 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
+          name: Log into ECR
+          command: |
+            source /tmp/mtp-env.sh
+            $(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)
+      - run:
           name: Build docker image
           command: |
             source /tmp/mtp-env.sh
+            docker pull ${registry}:base-web
+            docker tag ${registry}:base-web base-web
             docker build \
-              --pull --force-rm \
+              --force-rm \
               --build-arg APP_GIT_COMMIT=${CIRCLE_SHA1} \
               --build-arg APP_GIT_BRANCH=${CIRCLE_BRANCH} \
               --build-arg APP_BUILD_TAG=${tag} \
@@ -49,7 +56,6 @@ jobs:
           name: Push docker image
           command: |
             source /tmp/mtp-env.sh
-            $(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)
             echo "Pushing ${tag} to ECR"
             docker tag ${tag} ${registry}:${tag}
             docker push ${registry}:${tag}
@@ -58,6 +64,10 @@ jobs:
               docker tag ${tag} ${registry}:${app}
               docker push ${registry}:${app}
             fi
+      - run:
+          name: Log out of ECR
+          command: |
+            source /tmp/mtp-env.sh
             docker logout ${ECR_ENDPOINT}
       - run:
           name: Deploy to test

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ministryofjustice/prisoner-money

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,52 +1,12 @@
-FROM buildpack-deps:bionic
-
-# setup UK environment and install libraries and python
-RUN set -ex; \
-  apt-get update \
-  && \
-  DEBIAN_FRONTEND=noninteractive apt-get install \
-  -y --no-install-recommends --no-install-suggests \
-  -o DPkg::Options::=--force-confdef \
-  locales tzdata \
-  && \
-  echo en_GB.UTF-8 UTF-8 > /etc/locale.gen \
-  && \
-  locale-gen \
-  && \
-  rm /etc/localtime \
-  && \
-  ln -s /usr/share/zoneinfo/Europe/London /etc/localtime \
-  && \
-  dpkg-reconfigure --frontend noninteractive tzdata \
-  && \
-  DEBIAN_FRONTEND=noninteractive apt-get install \
-  -y --no-install-recommends --no-install-suggests \
-  -o DPkg::Options::=--force-confdef \
-  software-properties-common build-essential \
-  gettext rsync libssl1.0-dev \
-  python3-all-dev python3-setuptools python3-pip python3-wheel python3-venv \
-  nodejs nodejs-dev node-gyp npm \
-  chromium-browser \
-  && \
-  rm -rf /var/lib/apt/lists/* \
-  && \
-  npm set progress=false
-ENV LANG=en_GB.UTF-8
-ENV TZ=Europe/London
+FROM base-web
 
 # pre-create directories
-WORKDIR /app
 RUN set -ex; mkdir -p \
   mtp_bank_admin/assets \
   mtp_bank_admin/assets-static \
   static \
   media \
   spooler
-
-# install virtual environment
-RUN set -ex; \
-  /usr/bin/python3 -m venv venv && \
-  venv/bin/pip install -U setuptools pip wheel
 
 # cache python packages, unless requirements change
 COPY ./requirements requirements
@@ -56,8 +16,6 @@ RUN venv/bin/pip install -r requirements/docker.txt
 COPY . /app
 RUN set -ex; \
   venv/bin/python run.py --requirements-file requirements/docker.txt build \
-  && \
-  test $(id -u www-data) = 33 \
   && \
   chown -R www-data:www-data /app
 USER 33

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-# Money to Prisoners Bank Admin
+# Bank Admin
 
-The Bank Admin UI for the Money to Prisoners Project
-
+SSCL staff facing site for Prisoner Money suite of apps.
 
 ## Running locally
 
@@ -12,33 +11,32 @@ Please call this `venv` and make sure it's in the root folder of this applicatio
 In order to run the application locally, it is necessary to have the API running.
 Please refer to the [money-to-prisoners-api](https://github.com/ministryofjustice/money-to-prisoners-api/) repository.
 
-Once the API is running locally, run
+Once the API has started locally, run
 
 ```
+./run.py serve
+# or
 ./run.py start
 ```
 
-This will build everything (which will initially take a while) and run
-the local server at [http://localhost:8002](http://localhost:8002).
+This will build everything and run the local server at [http://localhost:8002](http://localhost:8002).
+
+You should be able to login using following credentials: `refund-bank-admin` or `disbursement-bank-admin`
 
 ### Alternative: Docker
 
 In order to run a server that's exactly similar to the production machines,
-you need to have [Docker](https://www.docker.com/docker-toolbox) installed. Run
+you need to have [Docker](https://www.docker.com/products/developer-tools) installed. Run
 
 ```
 ./run.py local_docker
 ```
 
-and you should eventually be able to connect to the local server.
-
-### Log in to the application
-
-You should be able to log into the cash book app using following credentials:
-
-- *bank-admin / bank-admin*
+and you should be able to connect to the local server.
 
 ## Developing
+
+[![CircleCI](https://circleci.com/gh/ministryofjustice/money-to-prisoners-bank-admin.svg?style=svg)](https://circleci.com/gh/ministryofjustice/money-to-prisoners-bank-admin)
 
 With the `run.py` command, you can run a browser-sync server, and get the assets
 to automatically recompile when changes are made, run `./run.py serve` instead of
@@ -61,9 +59,11 @@ python_dependencies --common-path [path]
 
 Update translation files with `./run.py make_messages` – you need to do this every time any translatable text is updated.
 
-Pull updates from Transifex with ``./run.py translations --pull``. You'll need to update translation files afterwards and manually check that the merges occurred correctly.
+Pull updates from Transifex with `./run.py translations --pull`.
+You'll need to update translation files afterwards and manually check that the merges occurred correctly.
 
-Push latest English to Transifex with ``./run.py translations --push``. NB: you should pull updates before pushing to merge correctly.
+Push latest English to Transifex with `./run.py translations --push`.
+NB: you should pull updates before pushing to merge correctly.
 
 ## Deploying
 

--- a/mtp_bank_admin/apps/bank_admin/urls.py
+++ b/mtp_bank_admin/apps/bank_admin/urls.py
@@ -1,3 +1,5 @@
+from urllib.parse import urljoin
+
 from django.conf import settings
 from django.conf.urls import url
 from django.contrib.auth.decorators import login_required
@@ -14,5 +16,5 @@ urlpatterns = [
     url(r'^bank_statement/download/$', views.download_bank_statement, name='download_bank_statement'),
     url(r'^disbursements/download/$', views.download_disbursements, name='download_disbursements'),
 
-    url(r'^q_and_a/$', RedirectView.as_view(url=settings.SEND_MONEY_URL + '/en-gb/help/faq/', permanent=True)),
+    url(r'^q_and_a/$', RedirectView.as_view(url=urljoin(settings.SEND_MONEY_URL, '/help/faq/'), permanent=True)),
 ]

--- a/mtp_bank_admin/settings/base.py
+++ b/mtp_bank_admin/settings/base.py
@@ -8,6 +8,7 @@ from functools import partial
 import os
 from os.path import abspath, dirname, join
 import sys
+from urllib.parse import urljoin
 
 BASE_DIR = dirname(dirname(abspath(__file__)))
 sys.path.insert(0, os.path.join(BASE_DIR, 'apps'))
@@ -26,8 +27,27 @@ SECRET_KEY = 'CHANGE_ME'
 ALLOWED_HOSTS = []
 
 START_PAGE_URL = os.environ.get('START_PAGE_URL', 'https://www.gov.uk/send-prisoner-money')
-SEND_MONEY_URL = os.environ.get('SEND_MONEY_URL', 'http://localhost:8004')
-SITE_URL = os.environ.get('SITE_URL', 'http://localhost:8002')
+CASHBOOK_URL = (
+    f'https://{os.environ["PUBLIC_CASHBOOK_HOST"]}'
+    if os.environ.get('PUBLIC_CASHBOOK_HOST')
+    else 'http://localhost:8001'
+)
+BANK_ADMIN_URL = (
+    f'https://{os.environ["PUBLIC_BANK_ADMIN_HOST"]}'
+    if os.environ.get('PUBLIC_BANK_ADMIN_HOST')
+    else 'http://localhost:8002'
+)
+NOMS_OPS_URL = (
+    f'https://{os.environ["PUBLIC_NOMS_OPS_HOST"]}'
+    if os.environ.get('PUBLIC_NOMS_OPS_HOST')
+    else 'http://localhost:8003'
+)
+SEND_MONEY_URL = (
+    f'https://{os.environ["PUBLIC_SEND_MONEY_HOST"]}'
+    if os.environ.get('PUBLIC_SEND_MONEY_HOST')
+    else 'http://localhost:8004'
+)
+SITE_URL = BANK_ADMIN_URL
 
 # Application definition
 INSTALLED_APPS = (
@@ -107,6 +127,7 @@ STATICFILES_DIRS = [
     get_project_dir('assets'),
     get_project_dir('assets-static'),
 ]
+PUBLIC_STATIC_URL = urljoin(SEND_MONEY_URL, STATIC_URL)
 
 TEMPLATES = [
     {

--- a/mtp_bank_admin/settings/base.py
+++ b/mtp_bank_admin/settings/base.py
@@ -214,26 +214,9 @@ TEST_RUNNER = 'mtp_common.test_utils.runner.TestRunner'
 # authentication
 SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'
 MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'
-
 AUTHENTICATION_BACKENDS = (
     'mtp_common.auth.backends.MojBackend',
 )
-
-
-def find_api_url():
-    import socket
-    import subprocess
-
-    api_port = int(os.environ.get('API_PORT', '8000'))
-    try:
-        host_machine_ip = subprocess.check_output(['docker-machine', 'ip', 'default'],
-                                                  stderr=subprocess.DEVNULL)
-        host_machine_ip = host_machine_ip.decode('ascii').strip()
-        with socket.socket() as sock:
-            sock.connect((host_machine_ip, api_port))
-    except (subprocess.CalledProcessError, OSError):
-        host_machine_ip = 'localhost'
-    return 'http://%s:%s' % (host_machine_ip, api_port)
 
 
 # control the time a session exists for; should match api's access token expiry
@@ -243,7 +226,7 @@ SESSION_SAVE_EVERY_REQUEST = True
 
 API_CLIENT_ID = 'bank-admin'
 API_CLIENT_SECRET = os.environ.get('API_CLIENT_SECRET', 'bank-admin')
-API_URL = os.environ.get('API_URL', find_api_url())
+API_URL = os.environ.get('API_URL', 'http://localhost:8000')
 
 LOGIN_URL = 'login'
 LOGIN_REDIRECT_URL = 'bank_admin:dashboard'

--- a/mtp_bank_admin/settings/base.py
+++ b/mtp_bank_admin/settings/base.py
@@ -54,6 +54,7 @@ INSTALLED_APPS = (
 PROJECT_APPS = (
     'anymail',
     'mtp_common',
+    'mtp_common.metrics',
     'widget_tweaks',
     'bank_admin',
     'zendesk_tickets'
@@ -78,6 +79,9 @@ MIDDLEWARE = (
 
 HEALTHCHECKS = []
 AUTODISCOVER_HEALTHCHECKS = True
+
+METRICS_USER = os.environ.get('METRICS_USER', 'prom')
+METRICS_PASS = os.environ.get('METRICS_PASS', 'prom')
 
 # security tightening
 # some overridden in prod/docker settings where SSL is ensured

--- a/mtp_bank_admin/settings/base.py
+++ b/mtp_bank_admin/settings/base.py
@@ -1,9 +1,3 @@
-"""
-Django settings for mtp_bank_admin project.
-
-For the full list of settings and their values, see
-https://docs.djangoproject.com/en/1.9/ref/settings/
-"""
 from functools import partial
 import os
 from os.path import abspath, dirname, join

--- a/mtp_bank_admin/urls.py
+++ b/mtp_bank_admin/urls.py
@@ -9,6 +9,7 @@ from django.views.generic import RedirectView, TemplateView
 from django.views.i18n import JavaScriptCatalog
 from moj_irat.views import HealthcheckView, PingJsonView
 from mtp_common.auth import views as auth_views
+from mtp_common.metrics.views import metrics_view
 
 urlpatterns = i18n_patterns(
     url(
@@ -83,6 +84,7 @@ urlpatterns += [
         version_number_key='APP_BUILD_TAG',
     ), name='ping_json'),
     url(r'^healthcheck.json$', HealthcheckView.as_view(), name='healthcheck_json'),
+    url(r'^metrics.txt$', metrics_view, name='prometheus_metrics'),
 
     url(r'^favicon.ico$', RedirectView.as_view(url=settings.STATIC_URL + 'images/favicon.ico', permanent=True)),
     url(r'^robots.txt$', lambda request: HttpResponse('User-agent: *\nDisallow: /', content_type='text/plain')),

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]>=9.13,<9.14
+money-to-prisoners-common[testing]>=9.15,<9.16
 
 mt-940==4.4

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,6 +1,6 @@
 # Place docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]>=9.13,<9.14
+money-to-prisoners-common[monitoring]>=9.15,<9.16
 
 uWSGI==2.0.18


### PR DESCRIPTION
- As apps are now able to discover each other, many environment variables are now redundant so they can be removed
- Apps now use base Docker images built by this repository (pulling from ECR or building locally) – this speeds up builds and ensures they have the same base OS
- Add prometheus service monitors for all apps
- Depends on [mtp-deploy#282](https://github.com/ministryofjustice/money-to-prisoners-deploy/pull/282)