### PR TITLE
MTP-1537: Removed dependencies already in mtp-common

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=11.0.1
+money-to-prisoners-common~=11.1.0
 
 mt940-writer==0.3
 openpyxl>=2.5,<2.5.14

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,16 +2,10 @@
 
 money-to-prisoners-common~=11.0.0
 
-Django>=2.2,<2.3
-requests>=2.22,<3
-django-widget-tweaks>=1.4,<1.5
 openpyxl>=2.5,<2.5.14
 Pillow>=5.3,<6
-transifex-client>=0.12
 django-anymail[mailgun]~=7.2
 uWSGI==2.0.19.1
-
 django-moj-irat>=0.6
-django-zendesk-tickets>=0.14
 
 mt940-writer==0.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,11 +1,7 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=11.0.0
-
-openpyxl>=2.5,<2.5.14
-Pillow>=5.3,<6
-django-anymail[mailgun]~=7.2
-uWSGI==2.0.19.1
-django-moj-irat>=0.6
+money-to-prisoners-common~=11.0.1
 
 mt940-writer==0.3
+openpyxl>=2.5,<2.5.14
+Pillow>=5.3,<6

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 # Place development and testing dependencies here
 
-money-to-prisoners-common[testing]~=11.0.0
+money-to-prisoners-common[testing]~=11.1.0
 
 -r base.txt
 


### PR DESCRIPTION
No point repeating these here and risk a conflict in the future.

⚠️ **NOTE**: ~Depends on `mtp-common` version `11.0.1` to be released/avaiable, see PR: https://github.com/ministryofjustice/money-to-prisoners-common/pull/407/~ - this now uses `mtp-common` `11.1.0`

Ticket: https://dsdmoj.atlassian.net/browse/MTP-1537