### PR TITLE
Stop producing Access Pay refunds files

### DIFF
--- a/bank_admin.ini
+++ b/bank_admin.ini
@@ -42,6 +42,7 @@ spooler-import = mtp_%n/tasks.py
 cron = 40 9 -1 -1 -1 %d/venv/bin/python %d/manage.py create_disbursements_file
 cron = 55 9 -1 -1 -1 %d/venv/bin/python %d/manage.py create_adi_journal_file
 cron = 0 10 -1 -1 -1 %d/venv/bin/python %d/manage.py create_bank_statement_file
-cron = 5 10 -1 -1 -1 %d/venv/bin/python %d/manage.py create_refund_file
+# Access Pay refunds files are always empty now so pre-caching is not needed (and raises an error):
+# cron = 5 10 -1 -1 -1 %d/venv/bin/python %d/manage.py create_refund_file
 cron = 0 11 -1 -1 -1 %d/venv/bin/python %d/manage.py send_private_estate_emails --scheduled
 cron = 0 23 -1 -1 -1 %d/venv/bin/python %d/manage.py clear_file_cache

--- a/mtp_bank_admin/apps/bank_admin/views.py
+++ b/mtp_bank_admin/apps/bank_admin/views.py
@@ -74,6 +74,7 @@ class DashboardView(TemplateView):
                 api_session, DISBURSEMENTS_LABEL, workday_list
             )
 
+        context['show_access_pay_refunds'] = settings.SHOW_ACCESS_PAY_REFUNDS
         return context
 
 

--- a/mtp_bank_admin/settings/base.py
+++ b/mtp_bank_admin/settings/base.py
@@ -287,11 +287,17 @@ CLOUD_PLATFORM_MIGRATION_URL = os.environ.get('CLOUD_PLATFORM_MIGRATION_URL', ''
 # general ledger account code for prisoner monies holding bank account
 PRISONER_MONEY_HOLDING_ACCOUNT = '1841102059'
 
+# whether to hide download links for Access Pay refunds files
+SHOW_ACCESS_PAY_REFUNDS = True
+
 # global setting to turn on all November 2 HMPPS policy changes
 NOVEMBER_SECOND_CHANGES_LIVE = os.environ.get('NOVEMBER_SECOND_CHANGES_LIVE', '').lower() in ('1', 'true')
 if NOVEMBER_SECOND_CHANGES_LIVE:
     # new bank account will be in use from this date
     PRISONER_MONEY_HOLDING_ACCOUNT = '1841102092'
+
+    # with credits by bank transfer no longer being allowed, refunds are not necessary
+    SHOW_ACCESS_PAY_REFUNDS = False
 
 try:
     from .local import *  # noqa

--- a/mtp_bank_admin/templates/bank_admin/dashboard.html
+++ b/mtp_bank_admin/templates/bank_admin/dashboard.html
@@ -61,8 +61,18 @@
   {% if perms.transaction.view_bank_details_transaction or perms.credit.view_any_credit %}
     <div class="govuk-grid-row">
       {% if perms.transaction.view_bank_details_transaction %}
-        {% url 'bank_admin:download_refund_file' as base_download_url %}
-        {% include 'bank_admin/downloads.html' with heading=_('Access Pay file – refunds') previous_heading=_('Previous Access Pay refund files') id='ap-refunds' %}
+        {% if show_access_pay_refunds %}
+          {% url 'bank_admin:download_refund_file' as base_download_url %}
+          {% include 'bank_admin/downloads.html' with heading=_('Access Pay file – refunds') previous_heading=_('Previous Access Pay refund files') id='ap-refunds' %}
+        {% else %}
+          <section class="govuk-grid-column-one-half">
+            <h2 class="govuk-heading-s">{% trans 'Access Pay file – refunds' %}</h2>
+            <p>
+              {% trans 'This file does not need to be downloaded anymore.' %}
+              {% trans 'There are no refunds to process through Access Pay.' %}
+            </p>
+          </section>
+        {% endif %}
       {% endif %}
 
       {% if perms.credit.view_any_credit %}


### PR DESCRIPTION
…because they're always empty now that credits by bank transfer are no longer supported.
Trying to download an empty file raises an `EmptyFileError` which is unnecessary noise in monitoring systems.

Relates to [MTP-1540](https://dsdmoj.atlassian.net/browse/MTP-1540), [MTP-1541](https://dsdmoj.atlassian.net/browse/MTP-1541)