### PR TITLE
Log variable data using a template string

### DIFF
--- a/mtp_bank_admin/apps/bank_admin/disbursements.py
+++ b/mtp_bank_admin/apps/bank_admin/disbursements.py
@@ -108,13 +108,13 @@ def generate_disbursements_journal(api_session, date):
 def add_private_estate_batches(journal, journal_date, prisons, private_estate_batches):
     for private_estate_batch in private_estate_batches:
         if not private_estate_batch.get('bank_account'):
-            logger.error('Private estate batch missing bank account %(prison)s %(date)s' % private_estate_batch)
+            logger.error('Private estate batch missing bank account %(prison)s %(date)s', private_estate_batch)
             continue
         if not private_estate_batch.get('remittance_emails'):
-            logger.error('Private estate batch missing remittance email addresses %(prison)s' % private_estate_batch)
+            logger.error('Private estate batch missing remittance email addresses %(prison)s', private_estate_batch)
             continue
         if not private_estate_batch['total_amount']:
-            logger.info('Nothing to transfer to %(prison)s for %(date)s' % private_estate_batch)
+            logger.info('Nothing to transfer to %(prison)s for %(date)s', private_estate_batch)
             continue
         prison = prisons[private_estate_batch['prison']]
         prison_name = prison.get('short_name') or prison['name']

--- a/mtp_bank_admin/apps/bank_admin/management/commands/send_private_estate_emails.py
+++ b/mtp_bank_admin/apps/bank_admin/management/commands/send_private_estate_emails.py
@@ -75,7 +75,7 @@ class Command(BaseCommand):
         batches = retrieve_private_estate_batches(self.api_session, start_date, end_date)
         grouped_batches = combine_private_estate_batches(batches)
         if not grouped_batches:
-            logger.info('No private estate batches to handle for %s' % date)
+            logger.info('No private estate batches to handle for %s', date)
             return
 
         prisons = retrieve_prisons(self.api_session)
@@ -143,10 +143,10 @@ def combine_private_estate_batches(private_estate_batches):
     batches = collections.defaultdict(list)
     for batch in private_estate_batches:
         if not batch['total_amount']:
-            logger.info('Skipping %(prison)s because there are no credits for %(date)s batch' % batch)
+            logger.info('Skipping %(prison)s because there are no credits for %(date)s batch', batch)
             continue
         if not batch.get('bank_account'):
-            logger.error('Private estate batch missing bank account %(prison)s %(date)s' % batch)
+            logger.error('Private estate batch missing bank account %(prison)s %(date)s', batch)
             continue
         batch['date'] = parse_date(batch['date'])
         batches[batch['prison']].append(batch)
@@ -184,7 +184,7 @@ def send_csv(prison, date, batches, csv_contents, total, count):
     email.attach_alternative(html_body, mimetype='text/html')
     email.attach(csv_name + '.zip', zipped_csv.getvalue(), mimetype='application/zip')
     email.send()
-    logger.info('Sent private estate batch for %s' % prison_name)
+    logger.info('Sent private estate batch for %s', prison_name)
 
 
 def csv_transaction_id(credit):

--- a/mtp_bank_admin/apps/bank_admin/views.py
+++ b/mtp_bank_admin/apps/bank_admin/views.py
@@ -97,7 +97,7 @@ def download_refund_file(request, receipt_date):
     response = HttpResponse(csvfile, content_type='text/plain')
     response['Content-Disposition'] = 'attachment; filename="%s"' % filename
 
-    logger.info('User "%(username)s" is downloading AccessPay file for %(date)s' % {
+    logger.info('User "%(username)s" is downloading AccessPay file for %(date)s', {
         'username': request.user.username,
         'date': date_format(receipt_date, 'Y-m-d'),
     })
@@ -130,7 +130,7 @@ def download_adi_journal(request, receipt_date):
     )
     response['Content-Disposition'] = 'attachment; filename="%s"' % filename
 
-    logger.info('User "%(username)s" is downloading ADI journal for %(date)s' % {
+    logger.info('User "%(username)s" is downloading ADI journal for %(date)s', {
         'username': request.user.username,
         'date': date_format(receipt_date, 'Y-m-d'),
     })
@@ -157,7 +157,7 @@ def download_bank_statement(request, receipt_date):
     response = HttpResponse(bai2file, content_type='application/octet-stream')
     response['Content-Disposition'] = 'attachment; filename="%s"' % filename
 
-    logger.info('User "%(username)s" is downloading bank statement file for %(date)s' % {
+    logger.info('User "%(username)s" is downloading bank statement file for %(date)s', {
         'username': request.user.username,
         'date': date_format(receipt_date, 'Y-m-d'),
     })
@@ -187,7 +187,7 @@ def download_disbursements(request, receipt_date):
     )
     response['Content-Disposition'] = 'attachment; filename="%s"' % filename
 
-    logger.info('User "%(username)s" is downloading Disbursements for %(date)s' % {
+    logger.info('User "%(username)s" is downloading Disbursements for %(date)s', {
         'username': request.user.username,
         'date': date_format(receipt_date, 'Y-m-d'),
     })

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=11.3.0
+money-to-prisoners-common~=11.4.0
 
 mt940-writer==0.3
 openpyxl>=2.5,<2.5.14

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 # Place development and testing dependencies here
 
-money-to-prisoners-common[testing]~=11.3.0
+money-to-prisoners-common[testing]~=11.4.0
 
 -r base.txt
 


### PR DESCRIPTION
…rather than an immediately formatted string. This allows Sentry to group messages by template, but still fully renders messages in the console.

[MTP-1863](https://dsdmoj.atlassian.net/browse/MTP-1863)

Depends on [common#419](https://github.com/ministryofjustice/money-to-prisoners-common/pull/419)