### PR TITLE
Turn on Sentry.io performance monitoring

### DIFF
--- a/mtp_bank_admin/settings/base.py
+++ b/mtp_bank_admin/settings/base.py
@@ -203,7 +203,8 @@ if os.environ.get('SENTRY_DSN'):
         integrations=[DjangoIntegration()],
         environment=ENVIRONMENT,
         release=APP_GIT_COMMIT or 'unknown',
-        send_default_pii=DEBUG,  # TODO: decide if prod apps should report user details
+        send_default_pii=DEBUG,
+        traces_sample_rate=0.5 if ENVIRONMENT == 'prod' else 1.0,
     )
 
 TEST_RUNNER = 'mtp_common.test_utils.runner.TestRunner'


### PR DESCRIPTION
…at 50% sample rate in production (this is a low/medium traffic app) and 100% in other environments.