### PR TITLE
MTP-1937: Use latest version of `mtp-common`

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,5 @@ This is handled by [money-to-prisoners-deploy](https://github.com/ministryofjust
 
 There are several dependencies of the ``money-to-prisoners-bank-admin`` python library which are maintained by this team, so they may require code-changes when the dependencies (e.g. Django) of the ``money-to-prisoners-bank-admin`` python library are incremented.
 
-* django-form-error-reporting: https://github.com/ministryofjustice/django-form-error-reporting
 * django-moj-irat: https://github.com/ministryofjustice/django-moj-irat
 * mt940-writer: https://github.com/ministryofjustice/mt940-writer

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=14.3.0
+money-to-prisoners-common~=15.0.0
 
 mt940-writer==0.6
 openpyxl~=3.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 # Place development and testing dependencies here
 
-money-to-prisoners-common[testing]~=14.3.0
+money-to-prisoners-common[testing]~=15.0.0
 
 -r base.txt
 


### PR DESCRIPTION
`bank-admin` doesn't define any forms so it doesn't directly use `django-form-error-reporting` but I'm updating the dependency to `mtp-common` for consistency.