### PR TITLE
MTP-1937: Removed legacy GA4 setting (`GOOGLE_ANALYTICS_ID`)

### DIFF
--- a/mtp_bank_admin/settings/base.py
+++ b/mtp_bank_admin/settings/base.py
@@ -262,7 +262,6 @@ LOGOUT_URL = 'logout'
 OAUTHLIB_INSECURE_TRANSPORT = True
 
 ANALYTICS_REQUIRED = os.environ.get('ANALYTICS_REQUIRED', 'True') == 'True'
-GOOGLE_ANALYTICS_ID = os.environ.get('GOOGLE_ANALYTICS_ID', None)
 GA4_MEASUREMENT_ID = os.environ.get('GA4_MEASUREMENT_ID', None)
 
 REFUND_REFERENCE = 'Refund %s %s'


### PR DESCRIPTION
`mtp-common` uses this setting to determine whether to send or not data to legacy GA.

It uses [`getattr(settings, 'GOOGLE_ANALYTICS_ID', None) `](https://github.com/ministryofjustice/money-to-prisoners-common/blob/199ccaf3507788ba7ea8080033a91be6a4312821/mtp_common/analytics.py#L21) so it's safe to remove the attribute as it would simply default to `None` instead of throwing an exception.

NOTE: `bank-admin` doesn't use any of the `Analytics.js` methods *directly* to send data to legacy GA. So after this there shouldn't be any use of the legacy GA methods in this application.