### PR TITLE
Django 4.2

### DIFF
--- a/mtp_bank_admin/apps/bank_admin/tests/test_adi.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_adi.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 import logging
 import os
 from unittest import mock, skipUnless
@@ -7,7 +7,6 @@ from urllib.parse import quote_plus
 
 from django.test.client import RequestFactory
 from django.urls import reverse
-from django.utils.timezone import utc
 from mtp_common.auth.api_client import get_api_session
 from mtp_common.auth.models import MojUser
 from mtp_common.test_utils import silence_logger
@@ -306,8 +305,8 @@ class AdiPaymentFileGenerationTestCase(BankAdminTestCase):
         self.assert_called_with(
             api_url('/transactions/reconcile/'), responses.POST,
             {
-                'received_at__gte': datetime(2016, 9, 13, 0, 0, tzinfo=utc).isoformat(),
-                'received_at__lt': datetime(2016, 9, 14, 0, 0, tzinfo=utc).isoformat()
+                'received_at__gte': datetime(2016, 9, 13, 0, 0, tzinfo=timezone.utc).isoformat(),
+                'received_at__lt': datetime(2016, 9, 14, 0, 0, tzinfo=timezone.utc).isoformat()
             }
         )
 

--- a/mtp_bank_admin/apps/bank_admin/tests/test_private_estate_emails.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_private_estate_emails.py
@@ -1,9 +1,9 @@
 import datetime
+from datetime import timezone
 from unittest import mock
 
 from django.core.management import call_command
 from django.test import SimpleTestCase, override_settings
-from django.utils.timezone import utc
 from mtp_common.auth.api_client import MoJOAuth2Session
 from mtp_common.auth.test_utils import generate_tokens
 from mtp_common.test_utils.notify import NotifyMock, GOVUK_NOTIFY_TEST_API_KEY
@@ -25,12 +25,12 @@ class PrivateEstateEmailTestCase(SimpleTestCase):
     def test_not_scheduled_on_weekend_or_bank_holiday(self, mocked_timezone, mocked_api_session):
         mocked_api_session.side_effect = AssertionError('Should not be called')
 
-        mocked_timezone.now.return_value = datetime.datetime(2019, 2, 17, 12, tzinfo=utc)
+        mocked_timezone.now.return_value = datetime.datetime(2019, 2, 17, 12, tzinfo=timezone.utc)
         with responses.RequestsMock() as rsps:
             mock_bank_holidays(rsps)
             call_command('send_private_estate_emails', scheduled=True)
 
-        mocked_timezone.now.return_value = datetime.datetime(2016, 12, 26, 12, tzinfo=utc)
+        mocked_timezone.now.return_value = datetime.datetime(2016, 12, 26, 12, tzinfo=timezone.utc)
         with responses.RequestsMock() as rsps:
             mock_bank_holidays(rsps)
             call_command('send_private_estate_emails', scheduled=True)
@@ -40,7 +40,7 @@ class PrivateEstateEmailTestCase(SimpleTestCase):
     def test_runs_on_weekday(self, mocked_timezone, mocked_api_session):
         mocked_api_session.side_effect = AssertionError('Must be called')
 
-        mocked_timezone.now.return_value = datetime.datetime(2019, 2, 18, 12, tzinfo=utc)
+        mocked_timezone.now.return_value = datetime.datetime(2019, 2, 18, 12, tzinfo=timezone.utc)
         with responses.RequestsMock() as rsps:
             mock_bank_holidays(rsps)
             with self.assertRaisesMessage(AssertionError, 'Must be called'):
@@ -50,7 +50,7 @@ class PrivateEstateEmailTestCase(SimpleTestCase):
     @mock.patch('bank_admin.management.commands.send_private_estate_emails.api_client.get_authenticated_api_session')
     @mock.patch('bank_admin.management.commands.send_private_estate_emails.timezone')
     def test_empty_batches(self, mocked_timezone, mocked_api_session, mocked_send_csv):
-        mocked_timezone.now.return_value = datetime.datetime(2019, 2, 18, 12, tzinfo=utc)
+        mocked_timezone.now.return_value = datetime.datetime(2019, 2, 18, 12, tzinfo=timezone.utc)
         mocked_send_csv.side_effect = AssertionError('Should not be called')
         with responses.RequestsMock() as rsps:
             mock_bank_holidays(rsps)
@@ -66,7 +66,7 @@ class PrivateEstateEmailTestCase(SimpleTestCase):
     @mock.patch('bank_admin.management.commands.send_private_estate_emails.api_client.get_authenticated_api_session')
     @mock.patch('bank_admin.management.commands.send_private_estate_emails.timezone')
     def test_csv_created(self, mocked_timezone, mocked_api_session, mocked_send_csv):
-        mocked_timezone.now.return_value = datetime.datetime(2019, 2, 18, 12, tzinfo=utc)
+        mocked_timezone.now.return_value = datetime.datetime(2019, 2, 18, 12, tzinfo=timezone.utc)
         with responses.RequestsMock() as rsps:
             mock_bank_holidays(rsps)
             mock_api_session(mocked_api_session)
@@ -213,7 +213,7 @@ class PrivateEstateEmailTestCase(SimpleTestCase):
     @mock.patch('bank_admin.management.commands.send_private_estate_emails.api_client.get_authenticated_api_session')
     @mock.patch('bank_admin.management.commands.send_private_estate_emails.timezone')
     def test_csv_created_for_one_prison(self, mocked_timezone, mocked_api_session, mocked_send_csv):
-        mocked_timezone.now.return_value = datetime.datetime(2019, 2, 18, 12, tzinfo=utc)
+        mocked_timezone.now.return_value = datetime.datetime(2019, 2, 18, 12, tzinfo=timezone.utc)
         with responses.RequestsMock() as rsps:
             mock_bank_holidays(rsps)
             mock_api_session(mocked_api_session)
@@ -276,7 +276,7 @@ class PrivateEstateEmailTestCase(SimpleTestCase):
     @mock.patch('bank_admin.management.commands.send_private_estate_emails.timezone.now')
     @override_settings(GOVUK_NOTIFY_API_KEY=GOVUK_NOTIFY_TEST_API_KEY)
     def test_email_sent(self, mocked_now, mocked_api_session, mocked_upload_to_s3):
-        mocked_now.return_value = datetime.datetime(2019, 2, 18, 12, tzinfo=utc)
+        mocked_now.return_value = datetime.datetime(2019, 2, 18, 12, tzinfo=timezone.utc)
         with NotifyMock() as rsps:
             mock_bank_holidays(rsps)
             mock_api_session(mocked_api_session)

--- a/mtp_bank_admin/apps/bank_admin/tests/test_refund.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_refund.py
@@ -1,10 +1,9 @@
 from copy import deepcopy
-from datetime import datetime, date
+from datetime import datetime, date, timezone
 from unittest import mock
 
 from django.test.client import RequestFactory
 from django.urls import reverse
-from django.utils.timezone import utc
 from mtp_common.auth.api_client import get_api_session
 from mtp_common.auth.models import MojUser
 import responses
@@ -120,8 +119,8 @@ class ValidTransactionsTestCase(RefundFileTestCase):
         self.assert_called_with(
             api_url('/transactions/reconcile/'), responses.POST,
             {
-                'received_at__gte': datetime(2016, 9, 13, 0, 0, tzinfo=utc).isoformat(),
-                'received_at__lt': datetime(2016, 9, 14, 0, 0, tzinfo=utc).isoformat()
+                'received_at__gte': datetime(2016, 9, 13, 0, 0, tzinfo=timezone.utc).isoformat(),
+                'received_at__lt': datetime(2016, 9, 14, 0, 0, tzinfo=timezone.utc).isoformat()
             }
         )
 

--- a/mtp_bank_admin/apps/bank_admin/tests/test_statement.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_statement.py
@@ -1,10 +1,9 @@
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 import random
 from unittest import mock
 
 from django.test.client import RequestFactory
 from django.urls import reverse
-from django.utils.timezone import utc
 import mt940
 from mtp_common.auth.api_client import get_api_session
 from mtp_common.auth.models import MojUser
@@ -136,8 +135,8 @@ class BankStatementGenerationTestCase(BankStatementTestCase):
         self.assert_called_with(
             api_url('/transactions/reconcile/'), responses.POST,
             {
-                'received_at__gte': datetime(2016, 9, 13, 0, 0, tzinfo=utc).isoformat(),
-                'received_at__lt': datetime(2016, 9, 14, 0, 0, tzinfo=utc).isoformat()
+                'received_at__gte': datetime(2016, 9, 13, 0, 0, tzinfo=timezone.utc).isoformat(),
+                'received_at__lt': datetime(2016, 9, 14, 0, 0, tzinfo=timezone.utc).isoformat()
             }
         )
 

--- a/mtp_bank_admin/apps/bank_admin/tests/test_utils.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_utils.py
@@ -1,7 +1,6 @@
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from unittest import mock
 
-from django.utils.timezone import utc
 from mtp_common.auth.api_client import get_api_session
 from mtp_common.auth.test_utils import generate_tokens
 import responses
@@ -33,13 +32,13 @@ class ReconcileForDateTestCase(BankAdminTestCase):
         self.assert_called_with(
             api_url('/transactions/reconcile/'), responses.POST,
             {
-                'received_at__gte': datetime(2016, 9, 15, 0, 0, tzinfo=utc).isoformat(),
-                'received_at__lt': datetime(2016, 9, 16, 0, 0, tzinfo=utc).isoformat()
+                'received_at__gte': datetime(2016, 9, 15, 0, 0, tzinfo=timezone.utc).isoformat(),
+                'received_at__lt': datetime(2016, 9, 16, 0, 0, tzinfo=timezone.utc).isoformat()
             }
         )
 
-        self.assertEqual(start_date, datetime(2016, 9, 15, 0, 0, tzinfo=utc))
-        self.assertEqual(end_date, datetime(2016, 9, 16, 0, 0, tzinfo=utc))
+        self.assertEqual(start_date, datetime(2016, 9, 15, 0, 0, tzinfo=timezone.utc))
+        self.assertEqual(end_date, datetime(2016, 9, 16, 0, 0, tzinfo=timezone.utc))
 
     @responses.activate
     def test_reconciles_weekend(self):
@@ -55,27 +54,27 @@ class ReconcileForDateTestCase(BankAdminTestCase):
         self.assert_called_with(
             api_url('/transactions/reconcile/'), responses.POST,
             {
-                'received_at__gte': datetime(2016, 10, 7, 0, 0, tzinfo=utc).isoformat(),
-                'received_at__lt': datetime(2016, 10, 8, 0, 0, tzinfo=utc).isoformat()
+                'received_at__gte': datetime(2016, 10, 7, 0, 0, tzinfo=timezone.utc).isoformat(),
+                'received_at__lt': datetime(2016, 10, 8, 0, 0, tzinfo=timezone.utc).isoformat()
             }
         )
         self.assert_called_with(
             api_url('/transactions/reconcile/'), responses.POST,
             {
-                'received_at__gte': datetime(2016, 10, 8, 0, 0, tzinfo=utc).isoformat(),
-                'received_at__lt': datetime(2016, 10, 9, 0, 0, tzinfo=utc).isoformat()
+                'received_at__gte': datetime(2016, 10, 8, 0, 0, tzinfo=timezone.utc).isoformat(),
+                'received_at__lt': datetime(2016, 10, 9, 0, 0, tzinfo=timezone.utc).isoformat()
             }
         )
         self.assert_called_with(
             api_url('/transactions/reconcile/'), responses.POST,
             {
-                'received_at__gte': datetime(2016, 10, 9, 0, 0, tzinfo=utc).isoformat(),
-                'received_at__lt': datetime(2016, 10, 10, 0, 0, tzinfo=utc).isoformat()
+                'received_at__gte': datetime(2016, 10, 9, 0, 0, tzinfo=timezone.utc).isoformat(),
+                'received_at__lt': datetime(2016, 10, 10, 0, 0, tzinfo=timezone.utc).isoformat()
             }
         )
 
-        self.assertEqual(start_date, datetime(2016, 10, 7, 0, 0, tzinfo=utc))
-        self.assertEqual(end_date, datetime(2016, 10, 10, 0, 0, tzinfo=utc))
+        self.assertEqual(start_date, datetime(2016, 10, 7, 0, 0, tzinfo=timezone.utc))
+        self.assertEqual(end_date, datetime(2016, 10, 10, 0, 0, tzinfo=timezone.utc))
 
 
 class WorkdayCheckerTestCase(BankAdminTestCase):

--- a/mtp_bank_admin/apps/bank_admin/tests/test_views.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_views.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 import logging
 from unittest import mock
 from urllib.parse import quote_plus
@@ -7,7 +7,6 @@ from django.conf import settings
 from django.test import override_settings
 from django.urls import reverse
 from django.utils.encoding import escape_uri_path
-from django.utils.timezone import utc
 from django.utils.translation import gettext_lazy as _
 from mtp_common.auth.exceptions import Forbidden
 from mtp_common.auth.test_utils import generate_tokens
@@ -251,8 +250,8 @@ class DownloadRefundFileViewTestCase(BankAdminViewTestCase):
                 limit=str(settings.REQUEST_PAGE_SIZE),
                 offset='0',
                 status='refundable',
-                received_at__gte=str(datetime(2014, 11, 12, 0, 0, tzinfo=utc)),
-                received_at__lt=str(datetime(2014, 11, 13, 0, 0, tzinfo=utc))
+                received_at__gte=str(datetime(2014, 11, 12, 0, 0, tzinfo=timezone.utc)),
+                received_at__lt=str(datetime(2014, 11, 13, 0, 0, tzinfo=timezone.utc))
             )
         )
         self.assert_called_with(
@@ -423,8 +422,8 @@ class DownloadAdiFileViewTestCase(BankAdminViewTestCase):
             '?receipt_date=2014-12-11'
         )
 
-        start_date = str(datetime(2014, 12, 11, 0, 0, tzinfo=utc))
-        end_date = str(datetime(2014, 12, 12, 0, 0, tzinfo=utc))
+        start_date = str(datetime(2014, 12, 11, 0, 0, tzinfo=timezone.utc))
+        end_date = str(datetime(2014, 12, 12, 0, 0, tzinfo=timezone.utc))
 
         self.assert_called_with(
             api_url('/credits/'), responses.GET,
@@ -606,8 +605,8 @@ class DownloadBankStatementViewTestCase(BankAdminViewTestCase):
             dict(
                 limit=str(settings.REQUEST_PAGE_SIZE),
                 offset='0',
-                received_at__gte=str(datetime(2014, 11, 12, 0, 0, tzinfo=utc)),
-                received_at__lt=str(datetime(2014, 11, 13, 0, 0, tzinfo=utc))
+                received_at__gte=str(datetime(2014, 11, 12, 0, 0, tzinfo=timezone.utc)),
+                received_at__lt=str(datetime(2014, 11, 13, 0, 0, tzinfo=timezone.utc))
             )
         )
         self.assert_called_with(
@@ -735,8 +734,8 @@ class DownloadDisbursementsFileViewTestCase(BankAdminViewTestCase):
             '?receipt_date=2014-12-11'
         )
 
-        start_date = str(datetime(2014, 12, 11, 0, 0, tzinfo=utc))
-        end_date = str(datetime(2014, 12, 12, 0, 0, tzinfo=utc))
+        start_date = str(datetime(2014, 12, 11, 0, 0, tzinfo=timezone.utc))
+        end_date = str(datetime(2014, 12, 12, 0, 0, tzinfo=timezone.utc))
 
         self.assert_called_with(
             api_url('/disbursements/'), responses.GET,

--- a/mtp_bank_admin/apps/bank_admin/urls.py
+++ b/mtp_bank_admin/apps/bank_admin/urls.py
@@ -1,20 +1,20 @@
 from urllib.parse import urljoin
 
 from django.conf import settings
-from django.conf.urls import url
 from django.contrib.auth.decorators import login_required
+from django.urls import re_path
 from django.views.generic import RedirectView
 
 from . import views
 
 app_name = 'bank_admin'
 urlpatterns = [
-    url(r'^$', login_required(views.DashboardView.as_view()), name='dashboard'),
+    re_path(r'^$', login_required(views.DashboardView.as_view()), name='dashboard'),
 
-    url(r'^refund_pending/download/$', views.download_refund_file, name='download_refund_file'),
-    url(r'^adi/download/$', views.download_adi_journal, name='download_adi_journal'),
-    url(r'^bank_statement/download/$', views.download_bank_statement, name='download_bank_statement'),
-    url(r'^disbursements/download/$', views.download_disbursements, name='download_disbursements'),
+    re_path(r'^refund_pending/download/$', views.download_refund_file, name='download_refund_file'),
+    re_path(r'^adi/download/$', views.download_adi_journal, name='download_adi_journal'),
+    re_path(r'^bank_statement/download/$', views.download_bank_statement, name='download_bank_statement'),
+    re_path(r'^disbursements/download/$', views.download_disbursements, name='download_disbursements'),
 
-    url(r'^q_and_a/$', RedirectView.as_view(url=urljoin(settings.SEND_MONEY_URL, '/help/faq/'), permanent=True)),
+    re_path(r'^q_and_a/$', RedirectView.as_view(url=urljoin(settings.SEND_MONEY_URL, '/help/faq/'), permanent=True)),
 ]

--- a/mtp_bank_admin/apps/feedback/urls.py
+++ b/mtp_bank_admin/apps/feedback/urls.py
@@ -1,6 +1,5 @@
 from django.conf import settings
-from django.conf.urls import url
-from django.urls import reverse_lazy
+from django.urls import reverse_lazy, re_path
 from mtp_common.views import GetHelpView as BaseGetHelpView, GetHelpSuccessView
 
 
@@ -11,6 +10,6 @@ class GetHelpView(BaseGetHelpView):
 
 
 urlpatterns = [
-    url(r'^feedback/$', GetHelpView.as_view(), name='submit_ticket'),
-    url(r'^feedback/success/$', GetHelpSuccessView.as_view(), name='feedback_success'),
+    re_path(r'^feedback/$', GetHelpView.as_view(), name='submit_ticket'),
+    re_path(r'^feedback/success/$', GetHelpSuccessView.as_view(), name='feedback_success'),
 ]

--- a/mtp_bank_admin/settings/docker.py
+++ b/mtp_bank_admin/settings/docker.py
@@ -32,6 +32,5 @@ if ENVIRONMENT != 'local':
     # strict-transport set at nginx level
     # SECURE_HSTS_SECONDS = 31536000
     # SECURE_HSTS_INCLUDE_SUBDOMAINS = True
-    SECURE_BROWSER_XSS_FILTER = True
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True

--- a/mtp_bank_admin/urls.py
+++ b/mtp_bank_admin/urls.py
@@ -1,9 +1,8 @@
 from django.conf import settings
-from django.conf.urls import include, url
 from django.conf.urls.i18n import i18n_patterns
 from django.http import HttpResponse
 from django.template.response import TemplateResponse
-from django.urls import reverse_lazy
+from django.urls import include, reverse_lazy, re_path
 from django.views.decorators.cache import cache_control
 from django.views.generic import RedirectView
 from django.views.i18n import JavaScriptCatalog
@@ -13,12 +12,12 @@ from mtp_common.metrics.views import metrics_view
 from mtp_common.views import SettingsView
 
 urlpatterns = i18n_patterns(
-    url(
+    re_path(
         r'^login/$', auth_views.login, {
             'template_name': 'mtp_auth/login.html',
         }, name='login'
     ),
-    url(
+    re_path(
         r'^logout/$', auth_views.logout, {
             'template_name': 'mtp_auth/login.html',
             'next_page': reverse_lazy('login'),
@@ -26,70 +25,70 @@ urlpatterns = i18n_patterns(
     ),
 
 
-    url(
+    re_path(
         r'^settings/$',
         SettingsView.as_view(),
         name='settings'
     ),
-    url(
+    re_path(
         r'^password_change/$', auth_views.password_change, {
             'template_name': 'mtp_common/auth/password_change.html',
             'cancel_url': reverse_lazy('settings'),
         }, name='password_change'
     ),
-    url(
+    re_path(
         r'^create_password/$', auth_views.password_change_with_code, {
             'template_name': 'mtp_common/auth/password_change_with_code.html',
             'cancel_url': reverse_lazy('bank_admin:dashboard'),
         }, name='password_change_with_code'
     ),
-    url(
+    re_path(
         r'^password_change_done/$', auth_views.password_change_done, {
             'template_name': 'mtp_common/auth/password_change_done.html',
             'cancel_url': reverse_lazy('bank_admin:dashboard'),
         }, name='password_change_done'
     ),
-    url(
+    re_path(
         r'^reset-password/$', auth_views.reset_password, {
             'password_change_url': reverse_lazy('password_change_with_code'),
             'template_name': 'mtp_common/auth/reset-password.html',
             'cancel_url': reverse_lazy('bank_admin:dashboard'),
         }, name='reset_password'
     ),
-    url(
+    re_path(
         r'^reset-password-done/$', auth_views.reset_password_done, {
             'template_name': 'mtp_common/auth/reset-password-done.html',
             'cancel_url': reverse_lazy('bank_admin:dashboard'),
         }, name='reset_password_done'
     ),
-    url(
+    re_path(
         r'^email_change/$', auth_views.email_change, {
             'cancel_url': reverse_lazy('settings'),
         }, name='email_change'
     ),
 
-    url(r'^', include('bank_admin.urls', namespace='bank_admin',)),
-    url(r'^', include('feedback.urls')),
-    url(r'^', include('mtp_common.user_admin.urls')),
+    re_path(r'^', include('bank_admin.urls', namespace='bank_admin',)),
+    re_path(r'^', include('feedback.urls')),
+    re_path(r'^', include('mtp_common.user_admin.urls')),
 
-    url(r'^js-i18n.js$', cache_control(public=True, max_age=86400)(JavaScriptCatalog.as_view()), name='js-i18n'),
+    re_path(r'^js-i18n.js$', cache_control(public=True, max_age=86400)(JavaScriptCatalog.as_view()), name='js-i18n'),
 
-    url(r'^404.html$', lambda request: TemplateResponse(request, 'mtp_common/errors/404.html', status=404)),
-    url(r'^500.html$', lambda request: TemplateResponse(request, 'mtp_common/errors/500.html', status=500)),
+    re_path(r'^404.html$', lambda request: TemplateResponse(request, 'mtp_common/errors/404.html', status=404)),
+    re_path(r'^500.html$', lambda request: TemplateResponse(request, 'mtp_common/errors/500.html', status=500)),
 )
 
 urlpatterns += [
-    url(r'^ping.json$', PingJsonView.as_view(
+    re_path(r'^ping.json$', PingJsonView.as_view(
         build_date_key='APP_BUILD_DATE',
         commit_id_key='APP_GIT_COMMIT',
         version_number_key='APP_BUILD_TAG',
     ), name='ping_json'),
-    url(r'^healthcheck.json$', HealthcheckView.as_view(), name='healthcheck_json'),
-    url(r'^metrics.txt$', metrics_view, name='prometheus_metrics'),
+    re_path(r'^healthcheck.json$', HealthcheckView.as_view(), name='healthcheck_json'),
+    re_path(r'^metrics.txt$', metrics_view, name='prometheus_metrics'),
 
-    url(r'^favicon.ico$', RedirectView.as_view(url=settings.STATIC_URL + 'images/favicon.ico', permanent=True)),
-    url(r'^robots.txt$', lambda request: HttpResponse('User-agent: *\nDisallow: /', content_type='text/plain')),
-    url(r'^\.well-known/security\.txt$', RedirectView.as_view(
+    re_path(r'^favicon.ico$', RedirectView.as_view(url=settings.STATIC_URL + 'images/favicon.ico', permanent=True)),
+    re_path(r'^robots.txt$', lambda request: HttpResponse('User-agent: *\nDisallow: /', content_type='text/plain')),
+    re_path(r'^\.well-known/security\.txt$', RedirectView.as_view(
         url='https://security-guidance.service.justice.gov.uk/.well-known/security.txt',
         permanent=True,
     )),

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=17.1.0
+money-to-prisoners-common~=18.0.0
 
 mt940-writer==0.7
 openpyxl~=3.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 # Place development and testing dependencies here
 
-money-to-prisoners-common[testing]~=17.1.0
+money-to-prisoners-common[testing]~=18.0.0
 
 -r base.txt
 


### PR DESCRIPTION
Changes needed to upgrade to Django 4.x (currently 3.2 is in use).

NOTE: So far this is not using Django 4.x but these are changes required to upgrade (e.g. because something deprecated was removed)