### PR TITLE
Fix stale cached bank statement files missing transactions after outage

### DIFF
--- a/mtp_bank_admin/apps/bank_admin/adi.py
+++ b/mtp_bank_admin/apps/bank_admin/adi.py
@@ -14,14 +14,15 @@ from .utils import (
 )
 
 
-def get_adi_journal_file(api_session, receipt_date, user=None):
+def get_adi_journal_file(api_session, receipt_date, user=None, force=False):
     filepath = get_or_create_file(
         ADI_JOURNAL_LABEL,
         receipt_date,
         generate_adi_journal,
         f_args=[api_session, receipt_date],
         f_kwargs={'user': user},
-        file_extension='xlsm'
+        file_extension='xlsm',
+        force=force
     )
     journal = AdiJournal(
         filepath,

--- a/mtp_bank_admin/apps/bank_admin/disbursements.py
+++ b/mtp_bank_admin/apps/bank_admin/disbursements.py
@@ -20,13 +20,14 @@ PAYMENT_METHODS = {
 }
 
 
-def get_disbursements_file(api_session, receipt_date, mark_sent=False):
+def get_disbursements_file(api_session, receipt_date, mark_sent=False, force=False):
     filepath = get_or_create_file(
         DISBURSEMENTS_LABEL,
         receipt_date,
         generate_disbursements_journal,
         f_args=[api_session, receipt_date],
-        file_extension='xlsm'
+        file_extension='xlsm',
+        force=force
     )
     if mark_sent:
         mark_as_sent(api_session, receipt_date)

--- a/mtp_bank_admin/apps/bank_admin/management/commands/__init__.py
+++ b/mtp_bank_admin/apps/bank_admin/management/commands/__init__.py
@@ -17,6 +17,10 @@ class FileGenerationCommand(BaseCommand):
     def add_arguments(self, parser):
         super().add_arguments(parser)
         parser.add_argument('--date', dest='date', type=str, help='Receipt date')
+        parser.add_argument(
+            '--force', action='store_true', dest='force', default=False,
+            help='Force regeneration of the file even if a cached copy already exists'
+        )
 
     def handle(self, *args, **options):
         if options['date']:
@@ -33,4 +37,4 @@ class FileGenerationCommand(BaseCommand):
             settings.BANK_ADMIN_USERNAME,
             settings.BANK_ADMIN_PASSWORD
         )
-        self.__class__.function(api_session, receipt_date)
+        self.__class__.function(api_session, receipt_date, force=options['force'])

--- a/mtp_bank_admin/apps/bank_admin/refund.py
+++ b/mtp_bank_admin/apps/bank_admin/refund.py
@@ -13,12 +13,13 @@ from .utils import (
 )
 
 
-def get_refund_file(api_session, receipt_date, mark_refunded=False):
+def get_refund_file(api_session, receipt_date, mark_refunded=False, force=False):
     filepath = get_or_create_file(
         ACCESSPAY_LABEL,
         receipt_date,
         generate_refund_file_for_date,
-        f_args=[api_session, receipt_date]
+        f_args=[api_session, receipt_date],
+        force=force
     )
     if mark_refunded:
         mark_as_refunded(api_session, receipt_date)

--- a/mtp_bank_admin/apps/bank_admin/statement.py
+++ b/mtp_bank_admin/apps/bank_admin/statement.py
@@ -11,12 +11,13 @@ from .utils import (
 )
 
 
-def get_bank_statement_file(api_session, receipt_date):
+def get_bank_statement_file(api_session, receipt_date, force=False):
     filepath = get_or_create_file(
         MT940_STMT_LABEL,
         receipt_date,
         generate_bank_statement,
-        f_args=[api_session, receipt_date]
+        f_args=[api_session, receipt_date],
+        force=force
     )
     return open(filepath, 'rb')
 

--- a/mtp_bank_admin/apps/bank_admin/tests/test_statement.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_statement.py
@@ -1,5 +1,7 @@
 from datetime import date, datetime, timezone
+import os
 import random
+import tempfile
 from unittest import mock
 
 from django.test.client import RequestFactory
@@ -13,7 +15,9 @@ from .utils import (
     get_test_transactions, NO_TRANSACTIONS, ORIGINAL_REF, SENDER_NAME,
     mock_balance, OPENING_BALANCE, api_url, mock_bank_holidays, BankAdminTestCase
 )
-from bank_admin.statement import generate_bank_statement
+from bank_admin.statement import generate_bank_statement, get_bank_statement_file
+from bank_admin.utils import get_cached_file_path
+from bank_admin import MT940_STMT_LABEL
 
 
 def get_test_transactions_for_stmt(count=20):
@@ -166,3 +170,66 @@ class NoTransactionsTestCase(BankStatementTestCase):
         final_closing_balance = parsed_file.data['final_closing_balance'].amount
         self.assertEqual(final_opening_balance, final_closing_balance)
         self.assertEqual(final_closing_balance.amount * 100, OPENING_BALANCE)
+
+
+class BankStatementCachingTestCase(BankStatementTestCase):
+    """Tests that the file cache can be bypassed with force=True."""
+
+    RECEIPT_DATE = date(2016, 9, 13)
+
+    def _setup_responses(self, transaction_count=20):
+        responses.add(
+            responses.POST,
+            api_url('/transactions/reconcile/'),
+            status=200
+        )
+        test_data = mock_test_transactions(count=transaction_count)
+        mock_balance()
+        mock_bank_holidays()
+        return test_data
+
+    @responses.activate
+    def test_cached_file_is_reused_without_force(self):
+        """Second call without force= returns the cached file without hitting the API."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = os.path.join(tmpdir, 'MT940_BANK_STMT', '20160913')
+            with mock.patch(
+                'bank_admin.utils.get_cached_file_path',
+                return_value=cache_path
+            ):
+                os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+                # Write a sentinel file to represent an already-cached statement
+                with open(cache_path, 'wb') as f:
+                    f.write(b'CACHED_CONTENT')
+
+                # Call without force — should return the existing cached file untouched
+                api_session = self.get_api_session()
+                returned = get_bank_statement_file(api_session, self.RECEIPT_DATE, force=False)
+                self.assertEqual(returned.read(), b'CACHED_CONTENT')
+                # No API calls should have been made
+                self.assertEqual(len(responses.calls), 0)
+
+    @responses.activate
+    def test_force_regenerates_cached_file(self):
+        """force=True causes the file to be regenerated even when a cached copy exists."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = os.path.join(tmpdir, 'MT940_BANK_STMT', '20160913')
+            with mock.patch(
+                'bank_admin.utils.get_cached_file_path',
+                return_value=cache_path
+            ):
+                os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+                # Write a stale sentinel file
+                with open(cache_path, 'wb') as f:
+                    f.write(b'STALE_CONTENT')
+
+                self._setup_responses(transaction_count=5)
+
+                api_session = self.get_api_session()
+                returned = get_bank_statement_file(api_session, self.RECEIPT_DATE, force=True)
+                content = returned.read()
+
+                # The stale sentinel should have been overwritten
+                self.assertNotEqual(content, b'STALE_CONTENT')
+                # The API should have been called
+                self.assertGreater(len(responses.calls), 0)

--- a/mtp_bank_admin/apps/bank_admin/tests/test_statement.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_statement.py
@@ -16,9 +16,6 @@ from .utils import (
     mock_balance, OPENING_BALANCE, api_url, mock_bank_holidays, BankAdminTestCase
 )
 from bank_admin.statement import generate_bank_statement, get_bank_statement_file
-from bank_admin.utils import get_cached_file_path
-from bank_admin import MT940_STMT_LABEL
-
 
 def get_test_transactions_for_stmt(count=20):
     transactions = get_test_transactions(count=int(count*0.75))

--- a/mtp_bank_admin/apps/bank_admin/utils.py
+++ b/mtp_bank_admin/apps/bank_admin/utils.py
@@ -185,12 +185,12 @@ def get_cached_file_path(label, date, extension=None):
     return filepath
 
 
-def get_or_create_file(label, date, creation_func, f_args=None, f_kwargs=None, file_extension=None):
+def get_or_create_file(label, date, creation_func, f_args=None, f_kwargs=None, file_extension=None, force=False):
     f_args = f_args or []
     f_kwargs = f_kwargs or {}
 
     filepath = get_cached_file_path(label, date, extension=file_extension)
-    if not os.path.isfile(filepath):
+    if force or not os.path.isfile(filepath):
         filedata = creation_func(*f_args, **f_kwargs)
         os.makedirs(os.path.dirname(filepath), exist_ok=True)
         with open(filepath, 'wb+') as f:


### PR DESCRIPTION
## Problem

The MT940 bank statement `.DAT` files downloaded from the bank-admin application were showing far fewer `:61:` transaction lines than expected between the `:60F:` (opening balance) and `:62F:` (closing balance) lines. In the most recent case only a single transaction was present for a date range spanning an entire weekend, when many more were expected.

**Example of the symptom:**
```
:20:32413
:25:10030603 607080
:28C:1/1
:60F:C260522GBP16952093,51
:61:2605260526C293789,50NMSC803518 BGC    ← only 1 line; should be many
:62F:C260526GBP17245883,01
```

Because the closing balance is computed as `opening_balance + sum(all transactions in file)`, a statement with missing transactions also produces a **wrong closing balance**. That balance is then used as the opening balance for the next day's statement, meaning the error cascades through every subsequent day's file.

## Root Cause

### Permanent file cache with no invalidation

`get_bank_statement_file()` in `statement.py` delegates to `get_or_create_file()` in `utils.py`:

```python
def get_or_create_file(label, date, creation_func, ...):
    filepath = get_cached_file_path(label, date, ...)
    if not os.path.isfile(filepath):   # only generates if file is absent
        filedata = creation_func(...)
        ...write to disk...
    return filepath                    # otherwise returns whatever is on disk
```

Once a file is written to `local_files/cache/MT940_BANK_STMT/YYYYMMDD` it is **served from cache forever**. There is no TTL, no expiry, no invalidation mechanism of any kind.

### How the outage triggered the problem

1. The **Transaction Uploader** (a separate cron service that fetches MT940 files from the bank SFTP server and POSTs them to the API) was down during the outage. Bank transactions for those days were not uploaded to the API.
2. The **bank-admin cron** (`0 10 * * *`, `bank_admin.ini` line 44) ran at 10:00 AM each morning as normal, calling `create_bank_statement_file`. It generated a statement with however many transactions happened to be in the API at that moment and **wrote the result to the cache**.
3. When the Transaction Uploader eventually recovered and uploaded the backlogged transactions, the cache files for those dates **already existed** and were never regenerated.
4. This same race condition can recur on any day where the Transaction Uploader is delayed past 10:00 AM.

### What was ruled out

- `retrieve_all_transactions()` passes **no status filter** to the API — it fetches all transactions in the date window regardless of reconciliation state.
- Pagination is handled correctly — bank-admin uses `REQUEST_PAGE_SIZE = 500` and `retrieve_all_pages_for_path` loops until all pages are consumed.
- The `GET /transactions/` API endpoint returns `Transaction.objects.all()` with no default queryset filtering.
- The `POST /transactions/reconcile/` step only assigns `ref_code` values; it does not exclude transactions from subsequent `GET` queries.

## Changes

### `utils.py` — add `force` parameter to `get_or_create_file`

```python
# before
def get_or_create_file(label, date, creation_func, f_args=None, f_kwargs=None, file_extension=None):
    ...
    if not os.path.isfile(filepath):

# after
def get_or_create_file(label, date, creation_func, f_args=None, f_kwargs=None, file_extension=None, force=False):
    ...
    if force or not os.path.isfile(filepath):
```

When `force=True` the cache check is skipped and the file is always regenerated.

### `statement.py`, `adi.py`, `disbursements.py`, `refund.py` — thread `force` through each public entry point

All four functions that call `get_or_create_file` gain a `force=False` keyword argument that is forwarded:

```python
def get_bank_statement_file(api_session, receipt_date, force=False):
    filepath = get_or_create_file(..., force=force)
```

The same pattern is applied to `get_adi_journal_file`, `get_disbursements_file`, and `get_refund_file`. This is fully backwards-compatible; all existing callers continue to work without any changes.

### `management/commands/__init__.py` — expose `--force` on `FileGenerationCommand`

`FileGenerationCommand` is the shared base class for all four file-generation management commands. Adding the flag here makes it available to all of them automatically:

```python
parser.add_argument(
    '--force', action='store_true', dest='force', default=False,
    help='Force regeneration of the file even if a cached copy already exists'
)
```

The `handle()` method passes `force=options['force']` through to the function.

### `tests/test_statement.py` — new `BankStatementCachingTestCase`

Two new tests verify the caching behaviour:

- **`test_cached_file_is_reused_without_force`** — pre-populates the cache path with a sentinel file, calls `get_bank_statement_file(..., force=False)`, and asserts the sentinel content is returned and no API calls are made.
- **`test_force_regenerates_cached_file`** — same setup, but calls with `force=True` and asserts the sentinel is overwritten and the API is called.

## Operational recovery

To regenerate the affected date(s) on the production pod after this is deployed:

```bash
# Regenerate a specific date's bank statement
./manage.py create_bank_statement_file --date YYYY-MM-DD --force

# The same flag works for the other three file types if needed
./manage.py create_adi_file --date YYYY-MM-DD --force
./manage.py create_disbursements_file --date YYYY-MM-DD --force
./manage.py create_refund_file --date YYYY-MM-DD --force
```

Alternatively, the stale cache files can be deleted directly and will be regenerated on the next download request:

```bash
rm local_files/cache/MT940_BANK_STMT/YYYYMMDD
```

---
