### PR TITLE
IR-1691 Make private estate reconcile resilient and add email heartbeat

### DIFF
--- a/bank_admin.ini
+++ b/bank_admin.ini
@@ -45,5 +45,6 @@ cron = 0 10 -1 -1 -1 %d/venv/bin/python %d/manage.py create_bank_statement_file
 # Access Pay refunds files are always empty now so pre-caching is not needed (and raises an error):
 # cron = 5 10 -1 -1 -1 %d/venv/bin/python %d/manage.py create_refund_file
 cron = 0 11 -1 -1 -1 %d/venv/bin/python %d/manage.py send_private_estate_emails --scheduled
+cron = 30 11 -1 -1 -1 %d/venv/bin/python %d/manage.py check_private_estate_emails
 cron = 0 23 -1 -1 -1 %d/venv/bin/python %d/manage.py clear_file_cache
 cron = 12 8 -1 -1 1 %d/venv/bin/python %d/manage.py check_notify_templates --verbosity 2

--- a/mtp_bank_admin/apps/bank_admin/management/commands/check_private_estate_emails.py
+++ b/mtp_bank_admin/apps/bank_admin/management/commands/check_private_estate_emails.py
@@ -1,0 +1,81 @@
+import logging
+
+from django.conf import settings
+from django.core.management import BaseCommand, CommandError
+from django.utils import timezone
+from django.utils.dateformat import format as format_date
+from django.utils.functional import cached_property
+from mtp_common.auth import api_client
+from mtp_common.notify import NotifyClient
+from mtp_common.stack import StackException, is_first_instance
+
+from bank_admin.disbursements import retrieve_private_estate_batches
+from bank_admin.utils import WorkdayChecker, get_start_and_end_date
+
+logger = logging.getLogger('mtp')
+
+
+class Command(BaseCommand):
+    """
+    Heartbeat for `send_private_estate_emails`: verifies that every private estate prison which had
+    credits for the previous working day actually had its email dispatched via GOV.UK Notify.
+
+    `send_private_estate_emails` runs at 11:00; this is scheduled shortly after. If a prison's email
+    is missing it raises, which surfaces in Sentry — rather than relying on the private estate
+    noticing and querying that they never received their credits.
+    """
+    help = 'Checks that private estate credit emails were sent for the previous working day'
+
+    @cached_property
+    def api_session(self):
+        return api_client.get_authenticated_api_session(
+            settings.BANK_ADMIN_USERNAME,
+            settings.BANK_ADMIN_PASSWORD,
+        )
+
+    def handle(self, **options):
+        try:
+            should_continue = is_first_instance()
+        except StackException:
+            should_continue = True
+        if not should_continue:
+            logger.info('Not checking private estate emails on non-key instance')
+            return
+
+        today = timezone.now().date()
+        workdays = WorkdayChecker()
+        if not workdays.is_workday(today):
+            logger.info('Non-workday: no private estate emails to check')
+            return
+        date = workdays.get_previous_workday(today)
+
+        expected_prisons = self.expected_prisons(date)
+        if not expected_prisons:
+            logger.info('No private estate batches to check for %s', date)
+            return
+
+        notify_client = NotifyClient.shared_client().client
+        reference_date = format_date(date, 'Y-m-d')
+        missing = []
+        for nomis_id in sorted(expected_prisons):
+            reference = 'bank-admin-private-csv-%s-%s' % (reference_date, nomis_id)
+            response = notify_client.get_all_notifications(reference=reference)
+            if not response.get('notifications'):
+                missing.append(nomis_id)
+
+        if missing:
+            logger.error('Private estate emails not sent for %s: %s', date, missing)
+            raise CommandError('Private estate emails not sent for %s: %s' % (date, missing))
+
+        logger.info('Confirmed %d private estate emails sent for %s', len(expected_prisons), date)
+
+    def expected_prisons(self, date):
+        start_date, end_date = get_start_and_end_date(date)
+        batches = retrieve_private_estate_batches(self.api_session, start_date, end_date)
+        # mirrors the batches that `send_private_estate_emails` would actually email:
+        # those with credits to send and a configured bank account
+        return {
+            batch['prison']
+            for batch in batches
+            if batch.get('total_amount') and batch.get('bank_account')
+        }

--- a/mtp_bank_admin/apps/bank_admin/tests/test_check_private_estate_emails.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_check_private_estate_emails.py
@@ -1,0 +1,136 @@
+import datetime
+from datetime import timezone
+import json
+from unittest import mock
+from urllib.parse import parse_qsl, urlsplit
+
+from django.core.management import CommandError, call_command
+from django.test import SimpleTestCase, override_settings
+from mtp_common.auth.api_client import MoJOAuth2Session
+from mtp_common.auth.test_utils import generate_tokens
+from mtp_common.notify import NotifyClient
+from mtp_common.test_utils.notify import (
+    GOVUK_NOTIFY_API_BASE_URL, GOVUK_NOTIFY_TEST_API_KEY, mock_all_templates_response,
+)
+import responses
+
+from bank_admin.tests.utils import TEST_BANK_ACCOUNT, api_url, mock_bank_holidays
+
+COMMAND = 'check_private_estate_emails'
+PATH = 'bank_admin.management.commands.check_private_estate_emails'
+
+
+def mock_api_session(mocked_api_session):
+    mock_session = MoJOAuth2Session()
+    mock_session.token = generate_tokens()
+    mocked_api_session.return_value = mock_session
+
+
+def mock_notifications(rsps, sent_references):
+    """
+    Fakes GOV.UK Notify's `get_all_notifications`: returns one notification for references that
+    were 'sent', and none otherwise.
+    """
+    def callback(request):
+        reference = dict(parse_qsl(urlsplit(request.url).query)).get('reference', '')
+        notifications = []
+        if reference in sent_references:
+            notifications = [{'id': '1', 'reference': reference, 'status': 'delivered'}]
+        return 200, {}, json.dumps({'notifications': notifications})
+
+    rsps.add_callback(
+        responses.GET,
+        f'{GOVUK_NOTIFY_API_BASE_URL}/v2/notifications',
+        callback=callback,
+        content_type='application/json',
+    )
+
+
+PRIVATE_ESTATE_BATCHES = {
+    'count': 2,
+    'results': [
+        {'date': '2019-02-15', 'prison': 'PR1', 'total_amount': 2500,
+         'bank_account': TEST_BANK_ACCOUNT, 'remittance_emails': ['private@mtp.local']},
+        {'date': '2019-02-15', 'prison': 'PR2', 'total_amount': 2000,
+         'bank_account': TEST_BANK_ACCOUNT, 'remittance_emails': ['private@mtp.local']},
+    ],
+}
+
+
+@override_settings(GOVUK_NOTIFY_API_KEY=GOVUK_NOTIFY_TEST_API_KEY)
+class CheckPrivateEstateEmailsTestCase(SimpleTestCase):
+    def setUp(self):
+        # the Notify client is cached across the process, ensure a fresh one per test
+        NotifyClient.shared_client.cache_clear()
+
+    @mock.patch(f'{PATH}.is_first_instance', return_value=True)
+    @mock.patch(f'{PATH}.api_client.get_authenticated_api_session')
+    @mock.patch(f'{PATH}.timezone')
+    def test_not_checked_on_weekend_or_bank_holiday(self, mocked_timezone, mocked_api_session, _mocked_first):
+        mocked_api_session.side_effect = AssertionError('Should not be called')
+
+        # Sunday
+        mocked_timezone.now.return_value = datetime.datetime(2019, 2, 17, 12, tzinfo=timezone.utc)
+        with responses.RequestsMock() as rsps:
+            mock_bank_holidays(rsps)
+            call_command(COMMAND)
+
+        # Boxing day (bank holiday)
+        mocked_timezone.now.return_value = datetime.datetime(2016, 12, 26, 12, tzinfo=timezone.utc)
+        with responses.RequestsMock() as rsps:
+            mock_bank_holidays(rsps)
+            call_command(COMMAND)
+
+    @mock.patch(f'{PATH}.is_first_instance', return_value=False)
+    @mock.patch(f'{PATH}.api_client.get_authenticated_api_session')
+    @mock.patch(f'{PATH}.timezone')
+    def test_skipped_on_non_key_instance(self, mocked_timezone, mocked_api_session, _mocked_first):
+        mocked_api_session.side_effect = AssertionError('Should not be called')
+        mocked_timezone.now.return_value = datetime.datetime(2019, 2, 18, 12, tzinfo=timezone.utc)
+        call_command(COMMAND)
+
+    @mock.patch(f'{PATH}.is_first_instance', return_value=True)
+    @mock.patch(f'{PATH}.api_client.get_authenticated_api_session')
+    @mock.patch(f'{PATH}.timezone')
+    def test_passes_when_all_prisons_sent(self, mocked_timezone, mocked_api_session, _mocked_first):
+        mocked_timezone.now.return_value = datetime.datetime(2019, 2, 18, 12, tzinfo=timezone.utc)
+        with responses.RequestsMock() as rsps:
+            mock_bank_holidays(rsps)
+            mock_api_session(mocked_api_session)
+            rsps.add(rsps.GET, api_url('private-estate-batches/'), json=PRIVATE_ESTATE_BATCHES)
+            mock_all_templates_response(rsps)
+            mock_notifications(rsps, sent_references={
+                'bank-admin-private-csv-2019-02-15-PR1',
+                'bank-admin-private-csv-2019-02-15-PR2',
+            })
+
+            call_command(COMMAND)
+
+    @mock.patch(f'{PATH}.is_first_instance', return_value=True)
+    @mock.patch(f'{PATH}.api_client.get_authenticated_api_session')
+    @mock.patch(f'{PATH}.timezone')
+    def test_raises_when_a_prison_missing(self, mocked_timezone, mocked_api_session, _mocked_first):
+        mocked_timezone.now.return_value = datetime.datetime(2019, 2, 18, 12, tzinfo=timezone.utc)
+        with responses.RequestsMock() as rsps:
+            mock_bank_holidays(rsps)
+            mock_api_session(mocked_api_session)
+            rsps.add(rsps.GET, api_url('private-estate-batches/'), json=PRIVATE_ESTATE_BATCHES)
+            mock_all_templates_response(rsps)
+            # PR2's email is missing from Notify
+            mock_notifications(rsps, sent_references={'bank-admin-private-csv-2019-02-15-PR1'})
+
+            with self.assertRaises(CommandError) as ctx:
+                call_command(COMMAND)
+            self.assertIn('PR2', str(ctx.exception))
+
+    @mock.patch(f'{PATH}.is_first_instance', return_value=True)
+    @mock.patch(f'{PATH}.api_client.get_authenticated_api_session')
+    @mock.patch(f'{PATH}.timezone')
+    def test_passes_when_no_batches(self, mocked_timezone, mocked_api_session, _mocked_first):
+        mocked_timezone.now.return_value = datetime.datetime(2019, 2, 18, 12, tzinfo=timezone.utc)
+        with responses.RequestsMock() as rsps:
+            mock_bank_holidays(rsps)
+            mock_api_session(mocked_api_session)
+            rsps.add(rsps.GET, api_url('private-estate-batches/'), json={'count': 0, 'results': []})
+
+            call_command(COMMAND)

--- a/mtp_bank_admin/apps/bank_admin/tests/test_utils.py
+++ b/mtp_bank_admin/apps/bank_admin/tests/test_utils.py
@@ -3,9 +3,12 @@ from unittest import mock
 
 from mtp_common.auth.api_client import get_api_session
 from mtp_common.auth.test_utils import generate_tokens
+import requests
 import responses
 
-from bank_admin.utils import WorkdayChecker, reconcile_for_date
+from bank_admin.utils import (
+    RECONCILE_MAX_ATTEMPTS, RECONCILE_RETRY_DELAY, WorkdayChecker, reconcile_for_date,
+)
 from .utils import mock_bank_holidays, api_url, BankAdminTestCase
 
 
@@ -75,6 +78,42 @@ class ReconcileForDateTestCase(BankAdminTestCase):
 
         self.assertEqual(start_date, datetime(2016, 10, 7, 0, 0, tzinfo=timezone.utc))
         self.assertEqual(end_date, datetime(2016, 10, 10, 0, 0, tzinfo=timezone.utc))
+
+    @responses.activate
+    @mock.patch('bank_admin.utils.systime.sleep')
+    def test_retries_reconcile_on_timeout(self, mocked_sleep):
+        mock_bank_holidays()
+        # first attempt times out, second succeeds
+        responses.add(
+            responses.POST, api_url('/transactions/reconcile/'),
+            body=requests.exceptions.ReadTimeout()
+        )
+        responses.add(responses.POST, api_url('/transactions/reconcile/'), status=200)
+
+        start_date, end_date = reconcile_for_date(self.api_session, date(2016, 9, 15))
+
+        reconcile_calls = [c for c in responses.calls if 'transactions/reconcile/' in c.request.url]
+        self.assertEqual(len(reconcile_calls), 2)
+        mocked_sleep.assert_called_once_with(RECONCILE_RETRY_DELAY)
+        self.assertEqual(start_date, datetime(2016, 9, 15, 0, 0, tzinfo=timezone.utc))
+        self.assertEqual(end_date, datetime(2016, 9, 16, 0, 0, tzinfo=timezone.utc))
+
+    @responses.activate
+    @mock.patch('bank_admin.utils.systime.sleep')
+    def test_reconcile_gives_up_after_max_attempts(self, mocked_sleep):
+        mock_bank_holidays()
+        for _ in range(RECONCILE_MAX_ATTEMPTS):
+            responses.add(
+                responses.POST, api_url('/transactions/reconcile/'),
+                body=requests.exceptions.ReadTimeout()
+            )
+
+        with self.assertRaises(requests.exceptions.Timeout):
+            reconcile_for_date(self.api_session, date(2016, 9, 15))
+
+        reconcile_calls = [c for c in responses.calls if 'transactions/reconcile/' in c.request.url]
+        self.assertEqual(len(reconcile_calls), RECONCILE_MAX_ATTEMPTS)
+        self.assertEqual(mocked_sleep.call_count, RECONCILE_MAX_ATTEMPTS - 1)
 
 
 class WorkdayCheckerTestCase(BankAdminTestCase):

--- a/mtp_bank_admin/apps/bank_admin/utils.py
+++ b/mtp_bank_admin/apps/bank_admin/utils.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from datetime import datetime, time, timedelta, timezone
 import io
 from itertools import count, islice
+import logging
 import time as systime
 import os
 
@@ -10,8 +11,20 @@ from mtp_common.api import retrieve_all_pages_for_path
 from mtp_common.dates import WorkdayChecker
 from openpyxl import load_workbook, styles
 from openpyxl.writer.excel import save_workbook
+import requests
 
 from .exceptions import EarlyReconciliationError
+
+logger = logging.getLogger('mtp')
+
+# The `transactions/reconcile/` endpoint reconciles the whole day's transactions, payments and
+# credits in a single DB transaction, so it can run close to the API client's default 30s timeout
+# at peak volume. Give this specific call a longer timeout and retry on timeout: the endpoint is
+# idempotent (it only acts on not-yet-reconciled records), so a retry simply completes any work a
+# timed-out attempt left outstanding.
+RECONCILE_REQUEST_TIMEOUT = 120  # seconds
+RECONCILE_MAX_ATTEMPTS = 3
+RECONCILE_RETRY_DELAY = 5  # seconds
 
 
 def retrieve_all_transactions(api_session, **kwargs):
@@ -49,16 +62,32 @@ def reconcile_for_date(api_session, receipt_date):
     reconciliation_date = start_date
     while reconciliation_date < end_date:
         end_of_day = reconciliation_date + timedelta(days=1)
-        api_session.post(
-            'transactions/reconcile/',
-            json={
-                'received_at__gte': reconciliation_date.isoformat(),
-                'received_at__lt': end_of_day.isoformat(),
-            }
-        )
+        _reconcile_day(api_session, reconciliation_date, end_of_day)
         reconciliation_date = end_of_day
 
     return start_date, end_date
+
+
+def _reconcile_day(api_session, reconciliation_date, end_of_day):
+    for attempt in range(1, RECONCILE_MAX_ATTEMPTS + 1):
+        try:
+            api_session.post(
+                'transactions/reconcile/',
+                json={
+                    'received_at__gte': reconciliation_date.isoformat(),
+                    'received_at__lt': end_of_day.isoformat(),
+                },
+                timeout=RECONCILE_REQUEST_TIMEOUT,
+            )
+            return
+        except requests.exceptions.Timeout:
+            if attempt >= RECONCILE_MAX_ATTEMPTS:
+                raise
+            logger.warning(
+                'Timed out reconciling %s (attempt %d/%d), retrying in %ds',
+                reconciliation_date.date(), attempt, RECONCILE_MAX_ATTEMPTS, RECONCILE_RETRY_DELAY,
+            )
+            systime.sleep(RECONCILE_RETRY_DELAY)
 
 
 def retrieve_last_balance(api_session, date):


### PR DESCRIPTION
## Problem

The daily `send_private_estate_emails --scheduled` run (11:00, uwsgi-cron) emails each private prison a CSV of credits received. Its **first** API call is `transactions/reconcile/`, which reconciles the whole day's transactions/payments/credits in one DB transaction and runs close to the API client's flat **30s** timeout at peak volume.

On 16 Jun 2026 the API actually completed the reconcile in **30.2s and returned 204**, but the client gave up at 30.0s → `ReadTimeout` → the command crashed **before sending any prison email**. The manual re-run's reconcile took only ~6s (most work already committed), confirming the call is idempotent and a retry would have absorbed the failure. The private estate is usually first to notice a miss, as there is no positive check that the emails went out.

## Changes

1. **Reconcile retry + per-call timeout** (`bank_admin/utils.py`) — `reconcile_for_date` now uses a 120s timeout for the reconcile POST (overriding the shared 30s default for this call only) and retries up to 3 times on `requests.exceptions.Timeout`. Scoped to the bank-admin call; the shared `mtp_common` default is untouched.

2. **Heartbeat command** (`check_private_estate_emails`, new) — scheduled at 11:30 daily, guarded by `is_first_instance()` + workday check. For the previous working day it verifies, via GOV.UK Notify, that every private estate prison with credits had its email dispatched (`bank-admin-private-csv-<date>-<nomis_id>` reference). Any missing prison raises `CommandError`, surfacing in Sentry — so a silent failure is caught without waiting for the prisons to query.

3. **Schedule** (`bank_admin.ini`) — adds the 11:30 cron line.

## Tests

- Retry path: timeout-then-success and give-up-after-max-attempts (`test_utils.py`).
- Heartbeat: weekend/bank-holiday skip, non-key-instance skip, all-sent pass, missing-prison raise, no-batches pass (`test_check_private_estate_emails.py`).
- All targeted + regression tests pass (24/24); flake8 clean.

## Out of scope (follow-ups)
Per-prison send-loop resilience in `send_private_estate_emails`; API-side reconcile optimisation; Slack/Prometheus alerting.