### PR TITLE
IR-1734 Point 'Forgotten your password?' link to ServiceNow

### DIFF
--- a/mtp_bank_admin/settings/base.py
+++ b/mtp_bank_admin/settings/base.py
@@ -48,6 +48,11 @@ EMAILS_URL = (
     if os.environ.get('PUBLIC_EMAILS_HOST')
     else 'http://localhost:8006'
 )
+SERVICENOW_PASSWORD_RESET_URL = os.environ.get(
+    'SERVICENOW_PASSWORD_RESET_URL',
+    'https://mojprod.service-now.com/moj_sp?id=sc_cat_item'
+    '&sys_id=acc3d27e1b7e32103393a797b04bcbda&table=sc_cat_item',
+)
 SITE_URL = BANK_ADMIN_URL
 
 # Application definition


### PR DESCRIPTION
## What
Redirect the Bank admin sign-in 'Forgotten your password?' link to the new ServiceNow catalogue item, as part of migrating support logging from Zendesk to ServiceNow.

## Changes
- Add `SERVICENOW_PASSWORD_RESET_URL` setting.

Bank admin's sign-in page inherits the 'Forgotten your password?' link from the shared money-to-prisoners-common template. This setting makes the shared `servicenow_password_reset_url` resolve to the ServiceNow link.

## Depends on
money-to-prisoners-common#779 (released as 21.2.6). The `~=21.2.1` pin picks it up automatically on the next dependency update.