### PR TITLE
IR-1734 Revert sign-in password-reset link to internal flow

### DIFF
--- a/mtp_bank_admin/settings/base.py
+++ b/mtp_bank_admin/settings/base.py
@@ -48,11 +48,9 @@ EMAILS_URL = (
     if os.environ.get('PUBLIC_EMAILS_HOST')
     else 'http://localhost:8006'
 )
-SERVICENOW_PASSWORD_RESET_URL = os.environ.get(
-    'SERVICENOW_PASSWORD_RESET_URL',
-    'https://mojprod.service-now.com/moj_sp?id=sc_cat_item'
-    '&sys_id=acc3d27e1b7e32103393a797b04bcbda&table=sc_cat_item',
-)
+# Bank admin has no FAQ, so this only drives the shared sign-in "Forgotten your password?"
+# link: point it at the internal self-service reset flow rather than ServiceNow.
+SERVICENOW_PASSWORD_RESET_URL = os.environ.get('SERVICENOW_PASSWORD_RESET_URL', '/reset-password/')
 SITE_URL = BANK_ADMIN_URL
 
 # Application definition


### PR DESCRIPTION
## Why
Support saw a spike in generic password-reset cases after IR-1734 routed the reset link to ServiceNow — the previously self-service, email-based reset flow (`/reset-password/`) was being funnelled through support alongside account unlocks. This puts the self-service sign-in link back.

## Change
Bank admin has no Get help / FAQ page, so `SERVICENOW_PASSWORD_RESET_URL` only drives the shared sign-in **"Forgotten your password?"** link (rendered from the common login template). Its default is repointed at the internal self-service `/reset-password/` flow. No template or `money-to-prisoners-common` change.

## Notes
Merging deploys to **test** only for the support team to validate.